### PR TITLE
Changes to support t31 4.4 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ CXX = ${CROSS_COMPILE}g++
 
 CCACHE = ccache
 CFLAGS = -Wall -Wextra -Wno-unused-parameter -O2 -DNO_OPENSSL=1
+ifeq ($(KERNEL_VERSION_4),y)
+CFLAGS += -DKERNEL_VERSION_4
+endif
 CXXFLAGS = $(CFLAGS) -std=c++20
 LDFLAGS = -lrt
 LIBS = -limp -lalog -lsysutils -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lfreetype

--- a/src/IMP.cpp
+++ b/src/IMP.cpp
@@ -69,6 +69,7 @@ int IMP::framesource_init() {
 
     IMPFSChnAttr fs_chn_attr = create_fs_attr();
 
+#if !defined(KERNEL_VERSION_4)
 #if defined(PLATFORM_T31)
     // Set rotate before FS creation
     // IMP_Encoder_SetFisheyeEnableStatus(0, 1);
@@ -78,6 +79,7 @@ int IMP::framesource_init() {
         LOG_DEBUG("IMP_FrameSource_SetChnRotate() == " + std::to_string(ret));
         return ret;
     }
+#endif
 #endif
 
     ret = IMP_FrameSource_CreateChn(0, &fs_chn_attr);


### PR DESCRIPTION
Backstory on this PR is 4.4 kernel won't build against many of the sdk blobs for reasons of the `Unknown symbol dev_get_drvdata` being required by the blob, but in kernel 4.4 this is not feasible to export this symbol from what I've seen.

What that leaves us with is a 4.4 blob that doesn't have the `IMP_FrameSource_SetChnRotate` so this patch allows prudynt-t to compile against those sources.