### PR TITLE
encode from PCM to AAC or OPUS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ CFLAGS += -DKERNEL_VERSION_4
 endif
 
 ifneq (,$(findstring -static,$(LDFLAGS)))
-LIBS = -limp -lalog -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lfaac
+LIBS = -limp -lalog -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lfaac -lopus
 else
-LIBS = -limp -lalog -laudioProcess -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lfaac
+LIBS = -limp -lalog -laudioProcess -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lfaac -lopus
 endif
 
 ifneq (,$(findstring -DPLATFORM_T31,$(CFLAGS)))

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ CFLAGS += -DKERNEL_VERSION_4
 endif
 
 ifneq (,$(findstring -static,$(LDFLAGS)))
-LIBS = -limp -lalog -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift
+LIBS = -limp -lalog -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lfaac
 else
-LIBS = -limp -lalog -laudioProcess -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift
+LIBS = -limp -lalog -laudioProcess -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lfaac
 endif
 
 ifneq (,$(findstring -DPLATFORM_T31,$(CFLAGS)))

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,18 @@ deps() {
 
 	cd ../
 
+	echo "Build opus"
+	cd 3rdparty
+
+        if [[ "$2" == "-static" ]]; then
+		PRUDYNT_CROSS=$PRUDYNT_CROSS ../scripts/make_opus_deps.sh -static
+        else
+		PRUDYNT_CROSS=$PRUDYNT_CROSS ../scripts/make_opus_deps.sh
+        fi
+
+	cd ../
+
+
 	echo "Build libschrift"
 	cd 3rdparty
 	rm -rf libschrift
@@ -165,7 +177,6 @@ deps() {
 	make -j$(nproc)
 	make install
 	cd ../../
-
 }
 
 if [ $# -eq 0 ]; then

--- a/build.sh
+++ b/build.sh
@@ -149,6 +149,23 @@ deps() {
 	cp libmuslshim.* ../install/lib/
 	fi
 	cd $TOP
+
+	echo "Build faac"
+	cd 3rdparty
+	rm -rf faac
+	git clone --depth=1 https://github.com/knik0/faac.git
+	cd faac
+	sed -i 's/^#define MAX_CHANNELS 64/#define MAX_CHANNELS 1/' libfaac/coder.h
+	./bootstrap
+	if [[ "$2" == "-static" ]]; then
+		CC="${PRUDYNT_CROSS}gcc" ./configure --host mipsel-linux-gnu --prefix="$TOP/3rdparty/install" --enable-static --disable-shared
+	else
+		CC="${PRUDYNT_CROSS}gcc" ./configure --host mipsel-linux-gnu --prefix="$TOP/3rdparty/install" --disable-static --enable-shared
+	fi
+	make -j$(nproc)
+	make install
+	cd ../../
+
 }
 
 if [ $# -eq 0 ]; then

--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -219,8 +219,8 @@ audio: {
 	# input_agc_target_level_dbfs: 10;  # AGC target level in dBFS for audio input (0 to 31).
 	# input_agc_compression_gain_db: 0;  # AGC compression gain in dB for audio input (0 to 90).
 	# input_noise_suppression: 0;  # Noise suppression for audio input (0 to 3).
-	# output_format: "PCM";  # Output audio format to use ("AAC", "PCM").
-	# output_bitrate: 32000;  # Output AAC encoder bitrate to use (32000 to 128000)
+	# output_format: "OPUS";  # Output audio format to use ("AAC", "OPUS", "PCM").
+	# output_bitrate: 40000;  # Output encoder bitrate to use (32000 to 128000)
 };
 
 # Motion Settings

--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -219,6 +219,8 @@ audio: {
 	# input_agc_target_level_dbfs: 10;  # AGC target level in dBFS for audio input (0 to 31).
 	# input_agc_compression_gain_db: 0;  # AGC compression gain in dB for audio input (0 to 90).
 	# input_noise_suppression: 0;  # Noise suppression for audio input (0 to 3).
+	# output_format: "PCM";  # Output audio format to use ("AAC", "PCM").
+	# output_bitrate: 32000;  # Output AAC encoder bitrate to use (32000 to 128000)
 };
 
 # Motion Settings

--- a/scripts/make_libwebsockets_deps.sh
+++ b/scripts/make_libwebsockets_deps.sh
@@ -108,8 +108,11 @@ $STRIP ./lib/libwebsockets.so.19
 
 mkdir -p ../../install/
 mkdir -p ../../install/lib/
-cp ./lib/libwebsockets.a ../../install/lib/
-cp ./lib/libwebsockets.so.19 ../../install/lib/libwebsockets.so
+if [[ "$1" == "-static" ]]; then
+	cp ./lib/libwebsockets.a ../../install/lib/
+else
+	cp ./lib/libwebsockets.so.19 ../../install/lib/libwebsockets.so
+fi
 #cp -R ../include/libwebsockets ../../../include/
 cp -R include/* ../../install/include/
 

--- a/scripts/make_opus_deps.sh
+++ b/scripts/make_opus_deps.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# This script automates the process of setting up a cross-compilation
+# environment for the Opus library using CMake. It prepares the build
+# directory, sets the toolchain for cross-compilation, clones the Opus
+# repository if not present, configures the build using CMake, compiles the
+# library, and finally copies the built library and relevant headers to the
+# appropriate locations in the repository.
+# -----------------------------------------------------------------------------
+
+set -e
+set -o pipefail
+
+# Variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/../3rdparty"
+OPUS_REPO="https://github.com/xiph/opus"
+OPUS_DIR="${BUILD_DIR}/opus"
+OPUS_VER="82ac57d9f1aaf575800cf17373348e45b7ce6c0d"
+MAKEFILE="$SCRIPT_DIR/../Makefile"
+
+PRUDYNT_CROSS="${PRUDYNT_CROSS#ccache }"
+
+CC="${PRUDYNT_CROSS}gcc"
+CXX="${PRUDYNT_CROSS}g++"
+STRIP="${PRUDYNT_CROSS}strip --strip-unneeded"
+
+# Determine if building static or shared library
+BUILD_SHARED_LIBS=ON
+if [[ "$1" == "-static" ]]; then
+    BUILD_SHARED_LIBS=OFF
+fi
+
+# Create Opus build directory
+echo "Creating Opus build directory..."
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Clone Opus if not already present
+if [ ! -d "$OPUS_DIR" ]; then
+    echo "Cloning Opus..."
+    git clone "$OPUS_REPO"
+fi
+
+cd "$OPUS_DIR"
+
+# Checkout desired version
+if [[ -n "$OPUS_VER" ]]; then
+    git checkout $OPUS_VER
+else
+    echo "Pulling Opus master"
+fi
+
+# Create and navigate to build directory
+mkdir -p build
+cd build
+
+# Configure the Opus build with CMake
+echo "Configuring Opus library..."
+cmake \
+    -DCMAKE_SYSTEM_NAME=Linux \
+    -DCMAKE_SYSTEM_PROCESSOR=mipsle \
+    -DCMAKE_C_COMPILER=${CC} \
+    -DCMAKE_CXX_COMPILER=${CXX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-Os" \
+    -DCMAKE_CXX_FLAGS="-Os" \
+    -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/install" \
+    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
+    ..
+
+echo "Building Opus library..."
+make -j$(nproc)
+
+if [ -f "${BUILD_DIR}/install/lib/libopus.so" ]; then
+	$STRIP "${BUILD_DIR}/install/lib/libopus.so"
+fi
+
+# Install Opus library and headers
+echo "Installing Opus library and headers..."
+make install
+
+echo "Opus build complete!"

--- a/src/AACEncoder.cpp
+++ b/src/AACEncoder.cpp
@@ -1,0 +1,87 @@
+#include "AACEncoder.hpp"
+#include "Config.hpp"
+#include "Logger.hpp"
+
+static constexpr unsigned SAMPLE_RATE = 16000;
+static constexpr unsigned CHANNELS = 1;
+static constexpr unsigned AAC_BUFFER_SIZE = 1280 * 3;
+
+AACEncoder* AACEncoder::createNew(UsageEnvironment& env, FramedSource* inputSource) {
+    return new AACEncoder(env, inputSource);
+}
+
+AACEncoder::AACEncoder(UsageEnvironment& env, FramedSource* inputSource)
+    : FramedFilter(env, inputSource), inputSamples(0), outputBufferSize(AAC_BUFFER_SIZE),
+      faacEncoder(faacEncOpen(SAMPLE_RATE, CHANNELS, &inputSamples, &outputBufferSize)) {
+
+    outputBuffer = new unsigned char[outputBufferSize];
+
+    if (!faacEncoder) {
+        LOG_ERROR("Failed to open FAAC encoder");
+        return;
+    }
+
+    faacEncConfigurationPtr config = faacEncGetCurrentConfiguration(faacEncoder);
+    config->aacObjectType = LOW;
+    config->bandWidth = SAMPLE_RATE;
+    config->bitRate = cfg->audio.output_bitrate;
+    config->inputFormat = FAAC_INPUT_16BIT;
+    config->mpegVersion = MPEG4;
+    config->outputFormat = ADTS_STREAM;
+
+    // Disable to reduce CPU utilization
+    config->allowMidside = 0;
+    config->useTns = 0;
+
+    if (!faacEncSetConfiguration(faacEncoder, config)) {
+        LOG_ERROR("Failed to configure FAAC encoder");
+	return;
+    }
+}
+
+AACEncoder::~AACEncoder() {
+    delete outputBuffer;
+    if (faacEncoder) {
+        faacEncClose(faacEncoder);
+    }
+}
+
+void AACEncoder::doGetNextFrame() {
+    fInputSource->getNextFrame(fTo, fMaxSize, afterGettingFrame, this, FramedSource::handleClosure, this);
+}
+
+void AACEncoder::afterGettingFrame(void* clientData, unsigned frameSize, unsigned numTruncatedBytes,
+                                   struct timeval presentationTime, unsigned durationInMicroseconds) {
+    auto* encoder = static_cast<AACEncoder*>(clientData);
+    encoder->processFrame(frameSize, numTruncatedBytes, presentationTime, durationInMicroseconds);
+}
+
+void AACEncoder::processFrame(unsigned frameSize, unsigned numTruncatedBytes,
+                              struct timeval presentationTime, unsigned durationInMicroseconds) {
+    if (!faacEncoder) {
+        LOG_ERROR("FAAC encoder not available");
+	return;
+    }
+
+    unsigned numSamples = frameSize / sizeof(int16_t);
+
+    int bytesEncoded = faacEncEncode(
+        faacEncoder,
+	reinterpret_cast<int32_t*>(fTo),
+	numSamples,
+	outputBuffer,
+	outputBufferSize);
+    if (bytesEncoded < 0) {
+        LOG_WARN("Encoding failed with error code: " << bytesEncoded);
+        return;
+    }
+
+    std::memcpy(fTo, outputBuffer, bytesEncoded);
+
+    fFrameSize = bytesEncoded;
+    fNumTruncatedBytes = numTruncatedBytes;
+    fPresentationTime = presentationTime;
+    fDurationInMicroseconds = numSamples * 1000000 / SAMPLE_RATE;
+
+    afterGetting(this);
+}

--- a/src/AACEncoder.hpp
+++ b/src/AACEncoder.hpp
@@ -1,0 +1,30 @@
+#ifndef AAC_ENCODER_HPP
+#define AAC_ENCODER_HPP
+
+#include <faac.h>
+#include <liveMedia.hh>
+
+class AACEncoder : public FramedFilter {
+public:
+    static AACEncoder* createNew(UsageEnvironment& env, FramedSource* inputSource);
+
+    virtual ~AACEncoder() override;
+
+protected:
+    AACEncoder(UsageEnvironment& env, FramedSource* inputSource);
+
+private:
+    void doGetNextFrame() override;
+    void processFrame(unsigned frameSize, unsigned numTruncatedBytes,
+                      struct timeval presentationTime, unsigned durationInMicroseconds);
+
+    static void afterGettingFrame(void* clientData, unsigned frameSize, unsigned numTruncatedBytes,
+                                  struct timeval presentationTime, unsigned durationInMicroseconds);
+
+    unsigned char* outputBuffer;
+    unsigned long outputBufferSize;
+    unsigned long inputSamples;
+    faacEncHandle faacEncoder;
+};
+
+#endif // AAC_ENCODER_HPP

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -128,6 +128,9 @@ std::vector<ConfigItem<bool>> CFG::getBoolItems()
 std::vector<ConfigItem<const char *>> CFG::getCharItems()
 {
     return {
+#if defined(AUDIO_SUPPORT)
+        {"audio.output_format", audio.output_format, "PCM", [](const char *v) { return strcmp(v, "AAC") == 0 || strcmp(v, "PCM") == 0; }},
+#endif
         {"general.loglevel", general.loglevel, "INFO", [](const char *v) {
             std::set<std::string> a = {"EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARN", "NOTICE", "INFO", "DEBUG"};
             return a.count(std::string(v)) == 1;
@@ -180,6 +183,7 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
         {"audio.input_agc_compression_gain_db", audio.input_agc_compression_gain_db, 0, [](const int &v) { return v >= 0 && v <= 90; }},
         {"audio.input_noise_suppression", audio.input_noise_suppression, 0, [](const int &v) { return v >= 0 && v <= 3; }},
 #endif
+        {"audio.output_bitrate", audio.output_bitrate, 32000, validateIntGe0},
 #endif
         {"general.osd_pool_size", general.osd_pool_size, 1024, [](const int &v) { return v >= 0 && v <= 1024; }},
         {"general.imp_polling_timeout", general.imp_polling_timeout, 500, [](const int &v) { return v >= 1 && v <= 5000; }},

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -129,7 +129,10 @@ std::vector<ConfigItem<const char *>> CFG::getCharItems()
 {
     return {
 #if defined(AUDIO_SUPPORT)
-        {"audio.output_format", audio.output_format, "PCM", [](const char *v) { return strcmp(v, "AAC") == 0 || strcmp(v, "PCM") == 0; }},
+        {"audio.output_format", audio.output_format, "OPUS", [](const char *v) {
+            std::set<std::string> a = {"AAC", "OPUS", "PCM"};
+            return a.count(std::string(v)) == 1;
+	}},
 #endif
         {"general.loglevel", general.loglevel, "INFO", [](const char *v) {
             std::set<std::string> a = {"EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARN", "NOTICE", "INFO", "DEBUG"};
@@ -183,7 +186,7 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
         {"audio.input_agc_compression_gain_db", audio.input_agc_compression_gain_db, 0, [](const int &v) { return v >= 0 && v <= 90; }},
         {"audio.input_noise_suppression", audio.input_noise_suppression, 0, [](const int &v) { return v >= 0 && v <= 3; }},
 #endif
-        {"audio.output_bitrate", audio.output_bitrate, 32000, validateIntGe0},
+        {"audio.output_bitrate", audio.output_bitrate, 40000, validateIntGe0},
 #endif
         {"general.osd_pool_size", general.osd_pool_size, 1024, [](const int &v) { return v >= 0 && v <= 1024; }},
         {"general.imp_polling_timeout", general.imp_polling_timeout, 500, [](const int &v) { return v >= 1 && v <= 5000; }},

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -149,6 +149,8 @@ struct _audio {
     int input_agc_target_level_dbfs;
     int input_agc_compression_gain_db;    
 #endif
+    int output_bitrate;
+    const char *output_format;
 };
 #endif      
 struct _osd {            

--- a/src/Opus.cpp
+++ b/src/Opus.cpp
@@ -1,0 +1,71 @@
+#include "Config.hpp"
+#include "Logger.hpp"
+#include "Opus.hpp"
+
+static constexpr unsigned SAMPLE_RATE = 16000;
+static constexpr unsigned CHANNELS = 1;
+
+Opus* Opus::createNew(UsageEnvironment& env, FramedSource* inputSource) {
+    return new Opus(env, inputSource);
+}
+
+Opus::Opus(UsageEnvironment& env, FramedSource* inputSource)
+    : FramedFilter(env, inputSource) {
+
+    int opusError;
+    opusEncoder = opus_encoder_create(SAMPLE_RATE, CHANNELS, OPUS_APPLICATION_RESTRICTED_LOWDELAY, &opusError);
+    if (opusError != OPUS_OK) {
+        LOG_ERROR("Failed to create Opus encoder: " << opus_strerror(opusError));
+	return;
+    }
+
+    opusError = opus_encoder_ctl(opusEncoder, OPUS_SET_BITRATE(cfg->audio.output_bitrate));
+    if (opusError != OPUS_OK) {
+        LOG_ERROR("Failed to set bitrate for Opus encoder: " << opus_strerror(opusError));
+    }
+
+    int bitrate;
+    opusError = opus_encoder_ctl(opusEncoder, OPUS_GET_BITRATE(&bitrate));
+    if (opusError != OPUS_OK) {
+        LOG_ERROR("Failed to get bitrate from Opus encoder: " << opus_strerror(opusError));
+    } else {
+        LOG_INFO("Opus encoder bitrate set to: " << bitrate);
+    }
+}
+
+Opus::~Opus() {
+    if (opusEncoder) {
+        opus_encoder_destroy(opusEncoder);
+    }
+}
+
+void Opus::doGetNextFrame() {
+    fInputSource->getNextFrame(fTo, fMaxSize, afterGettingFrame, this, FramedSource::handleClosure, this);
+}
+
+void Opus::afterGettingFrame(void* clientData, unsigned frameSize, unsigned numTruncatedBytes,
+                             struct timeval presentationTime, unsigned durationInMicroseconds) {
+    auto* encoder = static_cast<Opus*>(clientData);
+    encoder->processFrame(frameSize, numTruncatedBytes, presentationTime, durationInMicroseconds);
+}
+
+void Opus::processFrame(unsigned frameSize, unsigned numTruncatedBytes,
+                        struct timeval presentationTime, unsigned durationInMicroseconds) {
+
+    unsigned numSamples = frameSize / sizeof(int16_t);
+    opus_int32 bytesEncoded = opus_encode(opusEncoder, reinterpret_cast<opus_int16*>(fTo),
+                                          numSamples, outputBuffer, BUFFER_SIZE);
+    if (bytesEncoded < 0) {
+        LOG_WARN("Opus encoding failed with error: " << opus_strerror(bytesEncoded));
+        return;
+    }
+
+    std::memcpy(fTo, outputBuffer, bytesEncoded);
+
+    fFrameSize = bytesEncoded;
+    fNumTruncatedBytes = numTruncatedBytes;
+    fPresentationTime = presentationTime;
+    fDurationInMicroseconds = numSamples * 1000000 / SAMPLE_RATE;
+
+    afterGetting(this);
+}

--- a/src/Opus.hpp
+++ b/src/Opus.hpp
@@ -1,0 +1,29 @@
+#ifndef OPUS_ENCODER_HPP
+#define OPUS_ENCODER_HPP
+
+#include <liveMedia.hh>
+#include <opus/opus.h>
+
+class Opus : public FramedFilter {
+public:
+    static Opus* createNew(UsageEnvironment& env, FramedSource* inputSource);
+    
+protected:
+    Opus(UsageEnvironment& env, FramedSource* inputSource);
+    virtual ~Opus();
+    
+private:
+    virtual void doGetNextFrame() override;
+    static void afterGettingFrame(void* clientData, unsigned frameSize,
+                                  unsigned numTruncatedBytes, struct timeval presentationTime,
+                                  unsigned durationInMicroseconds);
+
+    void processFrame(unsigned frameSize, unsigned numTruncatedBytes,
+                      struct timeval presentationTime, unsigned durationInMicroseconds);
+
+    static constexpr unsigned BUFFER_SIZE = 960;
+    OpusEncoder* opusEncoder;
+    unsigned char outputBuffer[BUFFER_SIZE];
+};
+
+#endif // OPUS_ENCODER_HPP


### PR DESCRIPTION
This allows us to stream AAC or OPUS over RTSP rather than PCM and save on bandwidth.

OPUS works great and is the new default. AAC has crackling issues and I suspect it's because faac expects 1024 samples and we're only providing 640.

See accompanying firmware change: https://github.com/themactep/thingino-firmware/pull/180