### PR TITLE
WS and JPEG rework

### DIFF
--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -189,13 +189,10 @@ stream1: {
 # ---------------------------------
 stream2: {
 	# enabled: true;  # Enable or disable Stream2.
-	# format: "JPEG";  # Video format for the stream (JPEG).
 	# jpeg_path: "/tmp/snapshot.jpg";  # File path for JPEG snapshots.
 	# jpeg_quality: 75;  # Quality of JPEG snapshots (1-100).
 	# jpeg_refresh: 1000;  # Refresh rate for JPEG snapshots (in milliseconds).
 	# jpeg_channel: 0;  # JPEG channel (0 or 1).
-	# width: 1920;  # Width of the JPEG snapshot (in pixels).
-	# height: 1080;  # Height of the JPEG snapshot (in pixels).
 };
 
 # WebSocket Settings

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -99,7 +99,6 @@ std::vector<ConfigItem<bool>> CFG::getBoolItems()
         {"stream0.audio_enabled", stream0.audio_enabled, true, validateBool},
 #endif
         {"stream0.enabled", stream0.enabled, true, validateBool},
-        {"stream0.power_saving", stream0.power_saving, true, validateBool},
         {"stream0.allow_shared", stream0.allow_shared, true, validateBool},
         {"stream0.osd.enabled", stream0.osd.enabled, true, validateBool},
         {"stream0.osd.font_stroke_enabled", stream0.osd.font_stroke_enabled, true, validateBool},
@@ -111,7 +110,6 @@ std::vector<ConfigItem<bool>> CFG::getBoolItems()
         {"stream1.audio_enabled", stream1.audio_enabled, true, validateBool},
 #endif
         {"stream1.enabled", stream1.enabled, true, validateBool},
-        {"stream1.power_saving", stream1.power_saving, true, validateBool},
         {"stream1.allow_shared", stream1.allow_shared, true, validateBool},     
         {"stream1.osd.enabled", stream1.osd.enabled, true, validateBool},
         {"stream1.osd.font_stroke_enabled", stream1.osd.font_stroke_enabled, true, validateBool},
@@ -121,7 +119,8 @@ std::vector<ConfigItem<bool>> CFG::getBoolItems()
         {"stream1.osd.user_text_enabled", stream1.osd.user_text_enabled, true, validateBool},
         {"stream2.enabled", stream2.enabled, true, validateBool},
         {"websocket.enabled", websocket.enabled, true, validateBool},
-        {"websocket.secured", websocket.secured, false, validateBool},
+        {"websocket.ws_secured", websocket.ws_secured, true, validateBool},
+        {"websocket.http_secured", websocket.http_secured, true, validateBool},
     };
 };
 
@@ -159,12 +158,11 @@ std::vector<ConfigItem<const char *>> CFG::getCharItems()
             std::set<std::string> a = {"CBR", "VBR", "SMART", "FIXQP", "CAPPED_VBR", "CAPPED_QUALITY"};
             return a.count(std::string(v)) == 1;
         }},
-        {"stream2.format", stream2.format, "JPEG", [](const char *v) {
-            std::set<std::string> a = {"JPEG"};
-            return a.count(std::string(v)) == 1;
-        }},
-        {"stream2.jpeg_path", stream2.jpeg_path, "/tmp/snapshot.jpg", validateCharNotEmpty},
+       {"stream2.jpeg_path", stream2.jpeg_path, "/tmp/snapshot.jpg", validateCharNotEmpty},
         {"websocket.name", websocket.name, "wss prudynt", validateCharNotEmpty},
+        {"websocket.usertoken", websocket.usertoken, "", [](const char *v) {
+            return std::string(v).length() < 32;
+        }},
     };
 };
 
@@ -181,8 +179,8 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
         {"audio.input_noise_suppression", audio.input_noise_suppression, 0, [](const int &v) { return v >= 0 && v <= 3; }},
 #endif
 #endif
-        {"general.osd_pool_size", general.osd_pool_size, 1024, [](const int &v) { return v >= 0 && v <= 1024; }},
         {"general.imp_polling_timeout", general.imp_polling_timeout, 500, [](const int &v) { return v >= 1 && v <= 5000; }},
+        {"general.osd_pool_size", general.osd_pool_size, 1024, [](const int &v) { return v >= 0 && v <= 1024; }},
         {"image.ae_compensation", image.ae_compensation, 128, validateInt255},
         {"image.anti_flicker", image.anti_flicker, 2, validateInt2},
         {"image.backlight_compensation", image.backlight_compensation, 0, [](const int &v) { return v >= 0 && v <= 10; }},
@@ -292,13 +290,12 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
         {"stream1.osd.user_text_rotation", stream1.osd.user_text_rotation, 0, validateInt360},
         {"stream1.width", stream1.width, 640, validateIntGe0},
         {"stream1.profile", stream1.profile, 2, validateInt2},
-        {"stream2.height", stream2.height, OSD_AUTO_VALUE, validateIntGe0},
         {"stream2.jpeg_channel", stream2.jpeg_channel, 0, validateIntGe0},
         {"stream2.jpeg_quality", stream2.jpeg_quality, 75, [](const int &v) { return v > 0 && v <= 100; }},
-        {"stream2.jpeg_refresh", stream2.jpeg_refresh, 1000, validateIntGe0},
-        {"stream2.width", stream2.width, OSD_AUTO_VALUE, validateIntGe0},
+        {"stream2.fps", stream2.fps, 25, [](const int &v) { return v > 1 && v <= 30; }},
         {"websocket.loglevel", websocket.loglevel, 4096, [](const int &v) { return v > 0 && v <= 1024; }},
         {"websocket.port", websocket.port, 8089, validateInt65535},
+        {"websocket.first_image_delay", websocket.first_image_delay, 100, validateInt65535},
     };
 };
 
@@ -676,25 +673,13 @@ CFG::CFG()
 
     if (stream2.jpeg_channel == 0)
     {
-        if (stream2.width == OSD_AUTO_VALUE)
-        {
-            set<int>("stream2.width", stream0.width, true);
-        }
-        if (stream2.height == OSD_AUTO_VALUE)
-        {
-            set<int>("stream2.height", stream0.height, true);
-        }
-    }
-    if (stream2.jpeg_channel == 1)
+        stream2.width = stream0.width;
+        stream2.height = stream0.height;
+    } 
+    else
     {
-        if (stream2.width == OSD_AUTO_VALUE)
-        {
-            set<int>("stream2.width", stream1.width, true);
-        }
-        if (stream2.height == OSD_AUTO_VALUE)
-        {
-            set<int>("stream2.height", stream1.height, true);
-        }
+        stream2.width = stream1.width;
+        stream2.height = stream1.height;        
     }
 
     libconfig::Setting &root = lc.getRoot();

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -212,13 +212,14 @@ struct _stream {
     bool allow_shared;
     const char *mode;
     const char *rtsp_endpoint;
-    const char *format;
+    const char *format{"JPEG"};
     /* JPEG stream*/
     int jpeg_quality;
     int jpeg_refresh;
     int jpeg_channel;
     const char *jpeg_path;
     _osd osd;
+    _stream_stats stats;
 #if defined(AUDIO_SUPPORT)    
     bool audio_enabled;
 #endif
@@ -245,10 +246,13 @@ struct _motion {
 };
 struct _websocket {
     bool enabled;
-    bool secured;
+    bool ws_secured;
+    bool http_secured;
     int port;
     int loglevel;
+    int first_image_delay;
     const char *name;
+    const char *usertoken{""};
 };
 
 class CFG {

--- a/src/IMPEncoder.cpp
+++ b/src/IMPEncoder.cpp
@@ -57,12 +57,6 @@ void IMPEncoder::initProfile()
     memset(&chnAttr, 0, sizeof(IMPEncoderCHNAttr));
     rcAttr = &chnAttr.rcAttr;
 
-    if (stream->fps == IMP_AUTO_VALUE)
-    {
-        std::string path = "stream" + std::to_string(encChn) + ".fps";
-        cfg->set<int>(path, cfg->sensor.fps, true);
-    }
-
 #if defined(PLATFORM_T31)
     IMPEncoderRcMode rcMode = IMP_ENC_RC_MODE_CAPPED_QUALITY;
     IMPEncoderProfile encoderProfile = IMP_ENC_PROFILE_AVC_HIGH;
@@ -77,8 +71,10 @@ void IMPEncoder::initProfile()
         IMP_Encoder_SetDefaultParam(&chnAttr, encoderProfile, IMP_ENC_RC_MODE_FIXQP,
                                     stream->width, stream->height, 24, 1, 0, 0, stream->jpeg_quality, 0);
         // 1000 / stream->jpeg_refresh
-        LOG_DEBUG("STREAM PROFILE " << encChn << ", " << encGrp << ", " << stream->format << ", "
-                                    << chnAttr.rcAttr.outFrmRate.frmRateNum << "fps, profile:" << stream->profile << ", " << stream->width << "x" << stream->height);
+        LOG_DEBUG("STREAM PROFILE " << encChn << ", " << 
+                    encGrp << ", " << stream->format << ", " << 
+                    chnAttr.rcAttr.outFrmRate.frmRateNum << "fps, profile:" << 
+                    stream->profile << ", " << stream->width << "x" << stream->height);
         return;
     }
 
@@ -316,11 +312,6 @@ int IMPEncoder::init()
     if(cfg->stream2.enabled && cfg->stream2.jpeg_channel == encChn && stream->allow_shared) {
         ret = IMP_Encoder_SetbufshareChn(2, encChn);
         LOG_DEBUG_OR_ERROR_AND_EXIT(ret, "IMP_Encoder_SetbufshareChn(2, " << encChn << ")");
-
-        if(stream->power_saving) {
-            stream->power_saving = false;
-            LOG_DEBUG("power saving disabled for stream" << encChn);
-        }
     }
 #endif
 

--- a/src/WS.cpp
+++ b/src/WS.cpp
@@ -1237,7 +1237,7 @@ signed char WS::stream_callback(struct lejp_ctx *ctx, char reason)
         else
         {
             switch (ctx->path_match)
-            {                              
+            {
             case PNT_STREAM_RTSP_ENDPOINT:
                 if (reason == LEJPCB_VAL_STR_END)
                     cfg->set<const char *>(u_ctx->path, strdup(ctx->buf));
@@ -2093,12 +2093,12 @@ int WS::ws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *use
          * so we have to collect all the data until we reach the last segment.
          * On receiving the first segment we should clear the rx_message
          */
-        if(lws_is_first_fragment(wsi))
+        if (lws_is_first_fragment(wsi))
             u_ctx->rx_message.clear();
 
         u_ctx->rx_message.append(json_data);
 
-        if(!lws_is_final_fragment(wsi))
+        if (!lws_is_final_fragment(wsi))
             return 0;    
 
         LOG_DDEBUG("u_ctx->rx_message: " << u_ctx->rx_message);
@@ -2125,7 +2125,7 @@ int WS::ws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *use
             u_ctx->flag &= ~PNT_FLAG_WS_REQUEST_PREVIEW;
 
             // drop overlapping image requests
-            if(u_ctx->flag & PNT_FLAG_WS_PREVIEW_PENDING) {
+            if (u_ctx->flag & PNT_FLAG_WS_PREVIEW_PENDING) {
                 LOG_DDEBUG("drop overlapping image request.");
                 return 0;
             };
@@ -2217,9 +2217,6 @@ int WS::ws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *use
             }
             u_ctx->flag &= ~(PNT_FLAG_WS_SEND_PREVIEW | PNT_FLAG_WS_PREVIEW_PENDING);
         }
-
-        // cleanup request pending flag
-        //u_ctx->flag &= ~PNT_FLAG_WS_REQUEST_PENDING;
         break;
 
     case LWS_CALLBACK_CLOSED:

--- a/src/WS.cpp
+++ b/src/WS.cpp
@@ -12,22 +12,47 @@
 #include "OSD.hpp"
 #include "worker.hpp"
 #include "globals.hpp"
+#include <filesystem>
+#include <sys/inotify.h>
+
+#include <iomanip>
 
 #define MODULE "WEBSOCKET"
 
 #pragma region keys_and_enums
 
+using namespace std::chrono;
+using namespace std::filesystem;
 /*
     ToDo's
     add new font scales
     add new font stroke
-    add osd pool size
-    add polling timeout
-    add stream power save
     add stream buffer sharing
-    add audio enabled per stream
 */
 const char *unsupported = "not supported on this plattform";
+
+/* u_ctx->flag */
+enum
+{
+    PNT_FLAG_SEPARATOR = 1,
+
+    PNT_FLAG_ROI_ARRAY = 2,
+    PNT_FLAG_ROI_ENTRY = 4,
+
+    PNT_FLAG_RESTART_RTSP = 32,
+    PNT_FLAG_RESTART_VIDEO = 64,
+    PNT_FLAG_RESTART_AUDIO = 128,
+
+    PNT_FLAG_WS_REQUEST_PENDING = 256,
+    PNT_FLAG_WS_PREVIEW_PENDING = 512,
+    PNT_FLAG_WS_REQUEST_PREVIEW = 1024,
+    PNT_FLAG_WS_SEND_PREVIEW = 2048,
+
+    PNT_FLAG_HTTP_SEND_MESSAGE = 4096,
+    PNT_FLAG_HTTP_RECEIVED_MESSAGE = 8192,
+    PNT_FLAG_HTTP_SEND_PREVIEW = 16384,
+    PNT_FLAG_HTTP_SEND_INVALID = 32768
+};
 
 /* ROOT */
 enum
@@ -62,14 +87,14 @@ static const char *const root_keys[] = {
 enum
 {
     PNT_GENERAL_LOGLEVEL = 1,
-    PNT_TEST,
-    PNT_TEST2
+    PNT_GENERAL_OSD_POOL_SIZE,
+    PNT_GENERAL_IMP_POLLING_TIMEOUT
 };
 
 static const char *const general_keys[] = {
     "loglevel",
-    "test",
-    "xxx"};
+    "osd_pool_size",
+    "imp_polling_timeout"};
 
 /* RTSP */
 enum
@@ -194,8 +219,10 @@ static const char *const audio_keys[] = {
 /* STREAM */
 enum
 {
-    PNT_STREAM_RTSP_ENDPOINT = 1,
+    PNT_STREAM_ENABLED = 1,
+    PNT_STREAM_AUDIO_ENABLED,
     PNT_STREAM_SCALE_ENABLED,
+    PNT_STREAM_RTSP_ENDPOINT,
     PNT_STREAM_FORMAT,
     PNT_STREAM_GOP,
     PNT_STREAM_MAX_GOP,
@@ -207,12 +234,15 @@ enum
     PNT_STREAM_ROTATION,
     PNT_STREAM_SCALE_WIDTH,
     PNT_STREAM_SCALE_HEIGHT,
+    PNT_STREAM_STATS,
     PNT_STREAM_OSD
 };
 
 static const char *const stream_keys[] = {
-    "rtsp_endpoint",
+    "enabled",
+    "audio_enabled",
     "scale_enabled",
+    "rtsp_endpoint",
     "format",
     "gop",
     "max_gop",
@@ -224,6 +254,7 @@ static const char *const stream_keys[] = {
     "rotation",
     "scale_width",
     "scale_height",
+    "stats",
     "osd"};
 
 /* STREAM2 (JPEG) */
@@ -232,14 +263,20 @@ enum
     PNT_STREAM2_JPEG_ENABLED = 1,
     PNT_STREAM2_JPEG_PATH,
     PNT_STREAM2_JPEG_QUALITY,
-    PNT_STREAM2_JPEG_REFRESH
+    //PNT_STREAM2_JPEG_REFRESH,
+    PNT_STREAM2_JPEG_CHANNEL,
+    PNT_STREAM2_STATS,
+    PNT_STREAM2_FPS
 };
 
 static const char *const stream2_keys[] = {
     "jpeg_enabled",
     "jpeg_path",
     "jpeg_quality",
-    "jpeg_refresh"};
+    //"jpeg_refresh",
+    "jpeg_channel",
+    "stats",
+    "fps"};
 
 /* OSD */
 enum
@@ -397,18 +434,31 @@ static const char *const action_keys[] = {
 char token[WEBSOCKET_TOKEN_LENGTH + 1]{0};
 char ws_send_msg[2048];
 
+struct snapshot_info
+{
+    int r;             // current requests
+    int rps;           // requests per second
+    int throttle = 50; // throttle value to set a variable request delay time
+    steady_clock::time_point last_snapshot_request;
+};
+
 struct user_ctx
 {
-    WS *ws;
-    bool s;
-    std::string root;
-    std::string path;
-    int signal;
+    std::string id;   // session id
+    struct lws *wsi;  // libwebsockets handle
+    std::string root; // json root path
+    std::string path; // json sub path
+    int value;        // to use a number in the JSON parser e.g. encChn (encoder channel)
+    int flag;         // bitmask info store e.g. JSON separator (“,”) or thread restart
     roi region;
-    int flag;
     int midx;
     int vidx;
     size_t post_data_size;
+    std::string rx_message;
+    std::string tx_message;
+    std::string message;
+    lws_sorted_usec_list_t sul; // lws Soft Timer
+    struct snapshot_info snapshot;
 };
 
 std::string generateToken(int length)
@@ -431,57 +481,83 @@ std::string generateToken(int length)
     return randomString;
 }
 
-void send_jpeg(struct lws *wsi)
+bool get_snapshot(std::vector<unsigned char> &image)
 {
+    std::ifstream file("/tmp/snapshot.jpg", std::ios::binary);
+    if (!file.is_open())
+    {
+        LOG_DDEBUG(strerror(errno));
+        return false;
+    }
 
-    std::vector<uint8_t> jpeg_data = Worker::capture_jpeg_image(2);
-    size_t jpeg_size = jpeg_data.size();
-    std::vector<unsigned char> jpeg_buf(LWS_PRE + jpeg_size);
-    memcpy(jpeg_buf.data() + LWS_PRE, jpeg_data.data(), jpeg_size);
-    lws_write(wsi, jpeg_buf.data() + LWS_PRE, jpeg_size, LWS_WRITE_BINARY);
+    file.seekg(0, std::ios::end);
+    size_t file_size = file.tellg();
+    if (file_size)
+    {
+        image.resize(LWS_PRE + file_size);
+        file.seekg(0, std::ios::beg);
+        file.read(reinterpret_cast<char *>(image.data() + LWS_PRE), file_size);
+        file.close();
+        return true;
+    }
+
+    return false;
 }
 
 template <typename... Args>
-void append_message(const char *t, Args &&...a)
+void append_session_msg(std::string &ws_send_msg, const char *t, Args &&...a)
 {
-
-    char message[128];
-    memset(message, 0, sizeof(message));
-    snprintf(message, sizeof(message), t, std::forward<Args>(a)...);
-    std::strcat(ws_send_msg, message);
+    char message[256];
+    std::memset(message, 0, sizeof(message));
+    std::snprintf(message, sizeof(message), t, std::forward<Args>(a)...);
+    ws_send_msg += message;
 }
 
 signed char WS::general_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if ((reason & LEJP_FLAG_CB_IS_VALUE) && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", general_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", general_keys[ctx->path_match - 1]);
+        
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
-        switch (ctx->path_match)
-        {
-        case PNT_GENERAL_LOGLEVEL:
-            if (reason == LEJPCB_VAL_STR_END)
-            {
-                if (cfg->set<const char *>(u_ctx->path, strdup(ctx->buf)))
-                {
-                    Logger::setLevel(ctx->buf);
-                }
-            }
-            append_message(
-                "\"%s\"", cfg->get<const char *>(u_ctx->path));
-            break;
+        if (ctx->path_match >= PNT_GENERAL_OSD_POOL_SIZE && ctx->path_match <= PNT_GENERAL_IMP_POLLING_TIMEOUT)
+        { // integer values
+            if (reason == LEJPCB_VAL_NUM_INT)
+                cfg->set<int>(u_ctx->path, atoi(ctx->buf));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
-
-        u_ctx->s = 1;
+        else 
+        {
+            switch (ctx->path_match)
+            {
+            case PNT_GENERAL_LOGLEVEL:
+                if (reason == LEJPCB_VAL_STR_END)
+                {
+                    if (cfg->set<const char *>(u_ctx->path, strdup(ctx->buf)))
+                    {
+                        Logger::setLevel(ctx->buf);
+                    }
+                }
+                append_session_msg(
+                    u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
+                break;                    
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+                break;
+            }
+        }
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -490,14 +566,16 @@ signed char WS::general_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::rtsp_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", rtsp_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", rtsp_keys[ctx->path_match - 1]);
+
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         // int values
         if (ctx->path_match >= PNT_RTSP_PORT && ctx->path_match <= PNT_RTSP_SEND_BUFFER_SIZE)
@@ -510,8 +588,8 @@ signed char WS::rtsp_callback(struct lejp_ctx *ctx, char reason)
                     // u_ctx->signal = PNT_THREAD_RTSP | PNT_THREAD_ACTION_RESTART; // restart RTSP
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
             // const char * values
         }
         else if (ctx->path_match >= PNT_RTSP_NAME && ctx->path_match <= PNT_RTSP_PASSWORD)
@@ -524,8 +602,8 @@ signed char WS::rtsp_callback(struct lejp_ctx *ctx, char reason)
                     // u_ctx->signal = PNT_THREAD_RTSP | PNT_THREAD_ACTION_RESTART;
                 }
             }
-            append_message(
-                "\"%s\"", cfg->get<const char *>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
         }
         else
         {
@@ -548,17 +626,20 @@ signed char WS::rtsp_callback(struct lejp_ctx *ctx, char reason)
                         // u_ctx->signal = PNT_THREAD_RTSP | PNT_THREAD_ACTION_RESTART;
                     }
                 }
-                append_message(
-                    "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+                append_session_msg(
+                    u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+                break;
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
                 break;
             }
         }
-
-        u_ctx->s = 1;
+        
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -567,14 +648,16 @@ signed char WS::rtsp_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::sensor_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", sensor_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", sensor_keys[ctx->path_match - 1]);
+
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         // int values
         if (ctx->path_match >= PNT_SENSOR_FPS && ctx->path_match <= PNT_SENSOR_HEIGHT)
@@ -588,8 +671,8 @@ signed char WS::sensor_callback(struct lejp_ctx *ctx, char reason)
                 }
             }
             */
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
         else
         {
@@ -606,8 +689,8 @@ signed char WS::sensor_callback(struct lejp_ctx *ctx, char reason)
                     }
                 }
                 */
-                append_message(
-                    "\"%s\"", cfg->get<const char *>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
                 break;
             case PNT_SENSOR_I2C_ADDRESS:
                 /* normally this cannot be set and is read from proc
@@ -619,17 +702,18 @@ signed char WS::sensor_callback(struct lejp_ctx *ctx, char reason)
                     }
                 }
                 */
-                append_message(
-                    "\"%#x\"", cfg->get<unsigned int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "\"%#x\"", cfg->get<unsigned int>(u_ctx->path));
                 break;
-            }
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+                break;                
+            }            
         }
-
-        u_ctx->s = 1;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -638,14 +722,16 @@ signed char WS::sensor_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", image_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", image_keys[ctx->path_match - 1]);
+
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         if (ctx->path_match == PNT_IMAGE_DEFOG_STRENGTH)
         {
@@ -658,11 +744,11 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                     IMP_ISP_Tuning_SetDefog_Strength(reinterpret_cast<uint8_t *>(&t));
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
 #else
-            append_message(
-                "%s", "null");
+            append_session_msg(
+                u_ctx->message, "%s", "null");
 #endif
         }
         else if (ctx->path_match >= PNT_IMAGE_CORE_WB_MODE && ctx->path_match <= PNT_IMAGE_WB_BGAIN)
@@ -683,12 +769,11 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                     }
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
         else
         {
-
             switch (ctx->path_match)
             {
             case PNT_IMAGE_BRIGHTNESS:
@@ -699,8 +784,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetBrightness(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_CONTRAST:
                 if (reason == LEJPCB_VAL_NUM_INT)
@@ -710,8 +795,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetContrast(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_HUE:
 #if !defined(PLATFORM_T10) && !defined(PLATFORM_T20) && !defined(PLATFORM_T21) && !defined(PLATFORM_T23) && !defined(PLATFORM_T30)
@@ -722,11 +807,11 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetBcshHue(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
 #else
-                append_message(
-                    "%s", "null");
+                append_session_msg(
+                    u_ctx->message, "%s", "null");
 #endif
                 break;
             case PNT_IMAGE_SATURATION:
@@ -737,8 +822,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetSaturation(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_SHARPNESS:
                 if (reason == LEJPCB_VAL_NUM_INT)
@@ -748,8 +833,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetSharpness(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_SINTER_STRENGTH:
                 if (reason == LEJPCB_VAL_NUM_INT)
@@ -759,8 +844,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetSinterStrength(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_TEMPER_STRENGTH:
                 if (reason == LEJPCB_VAL_NUM_INT)
@@ -770,8 +855,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetTemperStrength(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_VFLIP:
                 if (reason == LEJPCB_VAL_TRUE)
@@ -788,8 +873,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetISPVflip(IMPISP_TUNING_OPS_MODE_DISABLE);
                     }
                 }
-                append_message(
-                    "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+                append_session_msg(
+                    u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
                 break;
             case PNT_IMAGE_HFLIP:
                 if (reason == LEJPCB_VAL_TRUE)
@@ -806,8 +891,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetISPHflip(IMPISP_TUNING_OPS_MODE_DISABLE);
                     }
                 }
-                append_message(
-                    "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+                append_session_msg(
+                    u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
                 break;
             case PNT_IMAGE_ANTIFLICKER:
                 if (reason == LEJPCB_VAL_NUM_INT)
@@ -817,19 +902,24 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetAntiFlickerAttr((IMPISPAntiflickerAttr)cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_RUNNING_MODE:
-                if (reason == LEJPCB_VAL_NUM_INT)
                 {
-                    if (cfg->set<int>(u_ctx->path, atoi(ctx->buf)))
+                    if (reason == LEJPCB_VAL_NUM_INT)
                     {
-                        IMP_ISP_Tuning_SetISPRunningMode((IMPISPRunningMode)cfg->get<int>(u_ctx->path));
+                        if (cfg->set<int>(u_ctx->path, atoi(ctx->buf)))
+                        {
+                            IMP_ISP_Tuning_SetISPRunningMode((IMPISPRunningMode)cfg->get<int>(u_ctx->path));
+                        }
                     }
+
+                    IMPISPRunningMode running_mode;
+                    IMP_ISP_Tuning_GetISPRunningMode(&running_mode);
+                    append_session_msg(
+                        u_ctx->message, "%d", (int)running_mode);
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_AE_COMPENSATION:
 #if !defined(PLATFORM_T21)
@@ -840,12 +930,12 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetAeComp(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
 #else
-                append_message(
-                    "%s", "null");
+                append_session_msg(
+                    u_ctx->message, "%s", "null");
 #endif
             case PNT_IMAGE_DPC_STRENGTH:
 #if !defined(PLATFORM_T10) && !defined(PLATFORM_T20) && !defined(PLATFORM_T21) && !defined(PLATFORM_T23) && !defined(PLATFORM_T30)
@@ -856,11 +946,11 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetDPC_Strength(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
 #else
-                append_message(
-                    "%s", "null");
+                append_session_msg(
+                    u_ctx->message, "%s", "null");
 #endif
                 break;
             case PNT_IMAGE_DRC_STRENGTH:
@@ -872,11 +962,11 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetDRC_Strength(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
 #else
-                append_message(
-                    "%s", "null");
+                append_session_msg(
+                    u_ctx->message, "%s", "null");
 #endif
                 break;
             case PNT_IMAGE_HIGHLIGHT_DEPRESS:
@@ -887,8 +977,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetHiLightDepress(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_BACKLIGHT_COMPENSTATION:
 #if !defined(PLATFORM_T10) && !defined(PLATFORM_T20) && !defined(PLATFORM_T21) && !defined(PLATFORM_T23) && !defined(PLATFORM_T30)
@@ -899,11 +989,11 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetBacklightComp(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
 #else
-                append_message(
-                    "%s", "null");
+                append_session_msg(
+                    u_ctx->message, "%s", "null");
 #endif
                 break;
             case PNT_IMAGE_MAX_AGAIN:
@@ -914,8 +1004,8 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetMaxAgain(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_IMAGE_MAX_DGAIN:
                 if (reason == LEJPCB_VAL_NUM_INT)
@@ -925,17 +1015,18 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
                         IMP_ISP_Tuning_SetMaxDgain(cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+                break;                 
             }
         }
-
-        u_ctx->s = 1;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -945,18 +1036,21 @@ signed char WS::image_callback(struct lejp_ctx *ctx, char reason)
 #if defined(AUDIO_SUPPORT)
 signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", audio_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", audio_keys[ctx->path_match - 1]);
+
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         if (ctx->path_match == PNT_AUDIO_INPUT_HIGH_PASS_FILTER)
         {
             IMPAudioIOAttr ioattr;
-            int ret = IMP_AI_GetPubAttr(u_ctx->flag, &ioattr);
+            int ret = IMP_AI_GetPubAttr(u_ctx->value, &ioattr);
             if (ret == 0)
             {
                 if (reason == LEJPCB_VAL_TRUE)
@@ -974,8 +1068,8 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
                     }
                 }
             }
-            append_message(
-                "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+            append_session_msg(
+                u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
         }
         else if (ctx->path_match == PNT_AUDIO_INPUT_NOISE_SUPPRESSION)
         {
@@ -986,14 +1080,14 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
                     global_restart_audio = true;
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
 #if defined(PLATFORM_T10) || defined(PLATFORM_T20) || defined(PLATFORM_T21) || defined(PLATFORM_T23) || defined(PLATFORM_T30) || defined(PLATFORM_T31)
         else if (ctx->path_match == PNT_AUDIO_INPUT_AGC_ENABLED)
         {
             IMPAudioIOAttr ioattr;
-            int ret = IMP_AI_GetPubAttr(u_ctx->flag, &ioattr);
+            int ret = IMP_AI_GetPubAttr(u_ctx->value, &ioattr);
             if (ret == 0)
             {
                 if (reason == LEJPCB_VAL_TRUE)
@@ -1011,8 +1105,8 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
                     }
                 }
             }
-            append_message(
-                "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+            append_session_msg(
+                u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
         }
         else if (ctx->path_match == PNT_AUDIO_INPUT_AGC_TARGET_LEVEL_DBFS || ctx->path_match == PNT_AUDIO_INPUT_AGC_COMPRESSION_GAIN_DB)
         {
@@ -1023,12 +1117,12 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
                     global_restart_audio = true;
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
 #else
-        append_message(
-            "%s", "null");
+        append_session_msg(
+            u_ctx->message, "%s", "null");
     }
 #endif
         else
@@ -1040,40 +1134,40 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
                 {
                     if (cfg->set<bool>(u_ctx->path, true))
                     {
-                        IMP_AI_Enable(u_ctx->flag);
+                        IMP_AI_Enable(u_ctx->value);
                     }
                 }
                 else if (reason == LEJPCB_VAL_FALSE)
                 {
                     if (cfg->set<bool>(u_ctx->path, false))
                     {
-                        IMP_AI_Disable(u_ctx->flag);
+                        IMP_AI_Disable(u_ctx->value);
                     }
                 }
-                append_message(
-                    "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+                append_session_msg(
+                    u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
                 break;
             case PNT_AUDIO_INPUT_VOL:
                 if (reason == LEJPCB_VAL_NUM_INT)
                 {
                     if (cfg->set<int>(u_ctx->path, atoi(ctx->buf)))
                     {
-                        IMP_AI_SetVol(u_ctx->flag, global_audio[u_ctx->flag]->aiChn, cfg->get<int>(u_ctx->path));
+                        IMP_AI_SetVol(u_ctx->value, global_audio[u_ctx->value]->aiChn, cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_AUDIO_INPUT_GAIN:
                 if (reason == LEJPCB_VAL_NUM_INT)
                 {
                     if (cfg->set<int>(u_ctx->path, atoi(ctx->buf)))
                     {
-                        IMP_AI_SetGain(u_ctx->flag, global_audio[u_ctx->flag]->aiChn, cfg->get<int>(u_ctx->path));
+                        IMP_AI_SetGain(u_ctx->value, global_audio[u_ctx->value]->aiChn, cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_AUDIO_INPUT_ALC_GAIN:
 #if defined(PLATFORM_T21) || defined(PLATFORM_T31)
@@ -1084,20 +1178,23 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
                         IMP_AI_SetAlcGain(0, 0, cfg->get<int>(u_ctx->path));
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
 #else
-            append_message(
-                "\"%s\"", unsupported);
+            append_session_msg(
+                u_ctx->message, "\"%s\"", unsupported);
 #endif
                 break;
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+                break;                  
             }
         }
-        u_ctx->s = 1;
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1112,27 +1209,40 @@ signed char WS::stream_callback(struct lejp_ctx *ctx, char reason)
 
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-        // LOG_DEBUG("stream_callback: " << u_ctx->path << " = " << (char *)ctx->buf);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", stream_keys[ctx->path_match - 1]);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", stream_keys[ctx->path_match - 1]);
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
-        if ((ctx->path_match >= PNT_STREAM_GOP && ctx->path_match <= PNT_STREAM_OSD))
+        if (ctx->path_match >= PNT_STREAM_GOP && ctx->path_match <= PNT_STREAM_SCALE_HEIGHT)
         { // integer values
             if (reason == LEJPCB_VAL_NUM_INT)
                 cfg->set<int>(u_ctx->path, atoi(ctx->buf));
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
+        }
+        else if(ctx->path_match >= PNT_STREAM_ENABLED && ctx->path_match <= PNT_STREAM_SCALE_ENABLED)
+        { // bool values
+            if (reason == LEJPCB_VAL_TRUE)
+            {
+                cfg->set<bool>(u_ctx->path, true);
+            }
+            else if (reason == LEJPCB_VAL_FALSE)
+            {
+                cfg->set<bool>(u_ctx->path, false);
+            }
+            append_session_msg(
+                u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
         }
         else
         {
             switch (ctx->path_match)
-            {
+            {                              
             case PNT_STREAM_RTSP_ENDPOINT:
                 if (reason == LEJPCB_VAL_STR_END)
                     cfg->set<const char *>(u_ctx->path, strdup(ctx->buf));
-                append_message(
-                    "\"%s\"", cfg->get<const char *>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
                 break;
             case PNT_STREAM_SCALE_ENABLED:
                 if (reason == LEJPCB_VAL_TRUE)
@@ -1143,32 +1253,54 @@ signed char WS::stream_callback(struct lejp_ctx *ctx, char reason)
                 {
                     cfg->set<bool>(u_ctx->path, false);
                 }
-                append_message(
-                    "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+                append_session_msg(
+                    u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
                 break;
             case PNT_STREAM_FORMAT:
                 if (reason == LEJPCB_VAL_STR_END)
                     cfg->set<const char *>(u_ctx->path, strdup(ctx->buf));
-                append_message(
-                    "\"%s\"", cfg->get<const char *>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
                 break;
+            case PNT_STREAM_STATS:
+                if (reason == LEJPCB_VAL_NULL)
+                {
+                    uint8_t fps = 0;
+                    uint32_t bps = 0;
+                    if (u_ctx->root == "stream0")
+                    {
+                        fps = cfg->stream0.stats.fps;
+                        bps = cfg->stream0.stats.bps;
+                    }
+                    else if (u_ctx->root == "stream1")
+                    {
+                        fps = cfg->stream1.stats.fps;
+                        bps = cfg->stream1.stats.bps;
+                    }
+                    append_session_msg(
+                        u_ctx->message, "{\"fps\":%d,\"Bps\":%d}", fps, bps);
+                }
+                break;                
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+                break;                
             };
         }
-
-        u_ctx->s = 1;
     }
     else if (reason == LECPCB_PAIR_NAME && ctx->path_match == PNT_STREAM_OSD)
     {
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":{", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", stream_keys[ctx->path_match - 1]);
 
-        append_message(
-            "%s\"%s\":{", u_ctx->s ? "," : "", stream_keys[ctx->path_match - 1]);
+        // remove separator for sub section
+        u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
 
         lejp_parser_push(ctx, u_ctx,
                          osd_keys, LWS_ARRAY_SIZE(osd_keys), osd_callback);
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1177,14 +1309,16 @@ signed char WS::stream_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::stream2_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", stream2_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", stream2_keys[ctx->path_match - 1]);
+
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         switch (ctx->path_match)
         {
@@ -1197,8 +1331,8 @@ signed char WS::stream2_callback(struct lejp_ctx *ctx, char reason)
             {
                 cfg->set<bool>(u_ctx->path, false);
             }
-            append_message(
-                "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+            append_session_msg(
+                u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
             break;
         case PNT_STREAM2_JPEG_PATH:
             if (reason == LEJPCB_VAL_STR_END)
@@ -1207,8 +1341,8 @@ signed char WS::stream2_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "\"%s\"", cfg->get<const char *>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
             break;
         case PNT_STREAM2_JPEG_QUALITY:
             if (reason == LEJPCB_VAL_NUM_INT)
@@ -1217,9 +1351,10 @@ signed char WS::stream2_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
             break;
+        /*
         case PNT_STREAM2_JPEG_REFRESH:
             if (reason == LEJPCB_VAL_NUM_INT)
             {
@@ -1227,16 +1362,52 @@ signed char WS::stream2_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
             break;
+        */
+        case PNT_STREAM2_FPS:
+            if (reason == LEJPCB_VAL_NUM_INT)
+            {
+                if (cfg->set<int>(u_ctx->path, atoi(ctx->buf)))
+                {
+                }
+            }
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
+            break;       
+        case PNT_STREAM2_JPEG_CHANNEL:
+            if (reason == LEJPCB_VAL_NUM_INT)
+            {
+                if (cfg->set<int>(u_ctx->path, atoi(ctx->buf)))
+                {
+                }
+            }
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
+            break;
+        case PNT_STREAM2_STATS:
+            if (reason == LEJPCB_VAL_NULL)
+            {
+                uint8_t fps = 0;
+                uint32_t bps = 0;
+                if (u_ctx->root == "stream2")
+                {
+                    fps = cfg->stream2.stats.fps;
+                    bps = cfg->stream2.stats.bps;
+                }
+                append_session_msg(
+                    u_ctx->message, "{\"fps\":%d,\"Bps\":%d}", fps, bps);
+            }
+            break;
+        default:
+            u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+            break;             
         }
-
-        u_ctx->s = 1;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1245,15 +1416,16 @@ signed char WS::stream2_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
-        u_ctx->path = u_ctx->path + "." + std::string(ctx->path);
+        u_ctx->path = u_ctx->root + ".osd." + std::string(ctx->path);
 
-        // LOG_DEBUG("osd_callback: " << u_ctx->path << " = " << (char *)ctx->buf << ", " << ctx->path_match);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", osd_keys[ctx->path_match - 1]);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", osd_keys[ctx->path_match - 1]);
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         if (ctx->path_match >= PNT_OSD_TIME_TRANSPARENCY &&
             ctx->path_match <= PNT_OSD_LOGO_TRANSPARENCY)
@@ -1266,11 +1438,11 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
 
                     _regions regions;
 
-                    if (u_ctx->flag == 0)
+                    if (u_ctx->value == 0)
                     {
                         regions = cfg->stream0.osd.regions;
                     }
-                    else if (u_ctx->flag == 1)
+                    else if (u_ctx->value == 1)
                     {
                         regions = cfg->stream1.osd.regions;
                     }
@@ -1293,7 +1465,7 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                     }
 
                     IMPOSDGrpRgnAttr grpRgnAttr;
-                    int ret = IMP_OSD_GetGrpRgnAttr(hnd, u_ctx->flag, &grpRgnAttr);
+                    int ret = IMP_OSD_GetGrpRgnAttr(hnd, u_ctx->value, &grpRgnAttr);
 
                     if (ret == 0)
                     {
@@ -1301,12 +1473,12 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                         grpRgnAttr.show = 1;
                         grpRgnAttr.gAlphaEn = 1;
                         grpRgnAttr.fgAlhpa = cfg->get<int>(u_ctx->path);
-                        IMP_OSD_SetGrpRgnAttr(hnd, u_ctx->flag, &grpRgnAttr);
+                        IMP_OSD_SetGrpRgnAttr(hnd, u_ctx->value, &grpRgnAttr);
                     }
                 };
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
         // integer
         else if (ctx->path_match >= PNT_OSD_FONT_SIZE && ctx->path_match <= PNT_OSD_UPTIME_ROTATION)
@@ -1315,8 +1487,8 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
             {
                 cfg->set<int>(u_ctx->path, atoi(ctx->buf));
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
         }
         // bool
         else if (ctx->path_match >= PNT_OSD_ENABLED && ctx->path_match <= PNT_OSD_FONT_STROKE_ENABLED)
@@ -1329,8 +1501,8 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
             {
                 cfg->set<bool>(u_ctx->path, false);
             }
-            append_message(
-                "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+            append_session_msg(
+                u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
         }
         // const char *
         else if (ctx->path_match >= PNT_OSD_FONT_PATH && ctx->path_match <= PNT_OSD_LOGO_PATH)
@@ -1341,8 +1513,8 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "\"%s\"", cfg->get<const char *>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
         }
         // unsigned int
         else if (ctx->path_match >= PNT_OSD_FONT_COLOR && ctx->path_match <= PNT_OSD_FONT_STROKE_COLOR)
@@ -1353,8 +1525,8 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "\"%#x\"", cfg->get<unsigned int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "\"%#x\"", cfg->get<unsigned int>(u_ctx->path));
         }
         else
         {
@@ -1365,15 +1537,15 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                 {
                     cfg->set<int>(u_ctx->path, atoi(ctx->buf));
                     IMPOSDRgnAttr rgnAttr;
-                    memset(&rgnAttr, u_ctx->flag, sizeof(IMPOSDRgnAttr));
+                    memset(&rgnAttr, 0, sizeof(IMPOSDRgnAttr));
                     if (IMP_OSD_GetRgnAttr(3, &rgnAttr) == 0)
                     {
-                        if (u_ctx->flag == 0)
+                        if (u_ctx->value == 0)
                         {
                             OSD::set_pos(&rgnAttr, cfg->stream0.osd.pos_logo_x,
                                          cfg->stream0.osd.pos_logo_y, 0, 0, cfg->stream0.width, cfg->stream0.height);
                         }
-                        else if (u_ctx->flag == 1)
+                        else if (u_ctx->value == 1)
                         {
                             OSD::set_pos(&rgnAttr, cfg->stream1.osd.pos_logo_x,
                                          cfg->stream1.osd.pos_logo_y, 0, 0, cfg->stream1.width, cfg->stream1.height);
@@ -1381,23 +1553,23 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                         IMP_OSD_SetRgnAttr(3, &rgnAttr);
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_OSD_POS_LOGO_Y:
                 if (reason == LEJPCB_VAL_NUM_INT)
                 {
                     cfg->set<int>(u_ctx->path, atoi(ctx->buf));
                     IMPOSDRgnAttr rgnAttr;
-                    memset(&rgnAttr, u_ctx->flag, sizeof(IMPOSDRgnAttr));
+                    memset(&rgnAttr, 0, sizeof(IMPOSDRgnAttr));
                     if (IMP_OSD_GetRgnAttr(3, &rgnAttr) == 0)
                     {
-                        if (u_ctx->flag == 0)
+                        if (u_ctx->value == 0)
                         {
                             OSD::set_pos(&rgnAttr, cfg->stream0.osd.pos_logo_y,
                                          cfg->stream0.osd.pos_logo_y, 0, 0, cfg->stream0.width, cfg->stream0.height);
                         }
-                        else if (u_ctx->flag == 1)
+                        else if (u_ctx->value == 1)
                         {
                             OSD::set_pos(&rgnAttr, cfg->stream1.osd.pos_logo_y,
                                          cfg->stream1.osd.pos_logo_y, 0, 0, cfg->stream1.width, cfg->stream1.height);
@@ -1405,33 +1577,37 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
                         IMP_OSD_SetRgnAttr(3, &rgnAttr);
                     }
                 }
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
             case PNT_OSD_LOGO_ROTATION:
                 // encoder restart required
                 if (reason == LEJPCB_VAL_NUM_INT)
                     cfg->set<int>(u_ctx->path, atoi(ctx->buf));
-                append_message(
-                    "%d", cfg->get<int>(u_ctx->path));
+                append_session_msg(
+                    u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
                 break;
+            default:
+                u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+                break;                 
             };
         }
-
-        u_ctx->s = 1;
-
-        if (u_ctx->flag == 0)
+        
+        /*
+        if (u_ctx->value == 0)
         {
             cfg->stream0.osd.thread_signal.fetch_or(2);
         }
-        else if (u_ctx->flag == 1)
+        else if (u_ctx->value == 1)
         {
             cfg->stream1.osd.thread_signal.fetch_or(2);
         }
+        */
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1440,15 +1616,15 @@ signed char WS::osd_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::motion_callback(struct lejp_ctx *ctx, char reason)
 {
-
     struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
     u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", motion_keys[ctx->path_match - 1]);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", motion_keys[ctx->path_match - 1]);
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
 
         // integer
         if (ctx->path_match >= PNT_MOTION_DEBOUNCE_TIME && ctx->path_match <= PNT_MOTION_ROI_COUNT)
@@ -1457,8 +1633,8 @@ signed char WS::motion_callback(struct lejp_ctx *ctx, char reason)
             {
                 cfg->set<int>(u_ctx->path, atoi(ctx->buf));
             }
-            append_message(
-                "%d", cfg->get<int>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "%d", cfg->get<int>(u_ctx->path));
             // bool
         }
         else if (ctx->path_match == PNT_MOTION_ENABLED)
@@ -1471,8 +1647,8 @@ signed char WS::motion_callback(struct lejp_ctx *ctx, char reason)
             {
                 cfg->set<bool>(u_ctx->path, false);
             }
-            append_message(
-                "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
+            append_session_msg(
+                u_ctx->message, "%s", cfg->get<bool>(u_ctx->path) ? "true" : "false");
             // std::string
         }
         else if (ctx->path_match == PNT_MOTION_SCRIPT_PATH)
@@ -1483,8 +1659,8 @@ signed char WS::motion_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "\"%s\"", cfg->get<const char *>(u_ctx->path));
+            append_session_msg(
+                u_ctx->message, "\"%s\"", cfg->get<const char *>(u_ctx->path));
         }
         else if (ctx->path_match == PNT_MOTION_ROIS)
         {
@@ -1494,26 +1670,29 @@ signed char WS::motion_callback(struct lejp_ctx *ctx, char reason)
                 {
                 }
             }
-            append_message(
-                "\"%s\"", cfg->get<std::string>(u_ctx->path).c_str());
+            append_session_msg(
+                u_ctx->message, "\"%s\"", cfg->get<std::string>(u_ctx->path).c_str());
         }
-
-        u_ctx->s = 1;
+        else
+        {
+            u_ctx->flag &= ~PNT_FLAG_SEPARATOR;             
+        }
     }
     else if (reason == LECPCB_PAIR_NAME && ctx->path_match == PNT_MOTION_ROIS)
     {
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", motion_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? ", " : "", motion_keys[ctx->path_match - 1]);
 
-        u_ctx->flag = 0;
+        // remove separator for sub section
+        u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+
         lejp_parser_push(ctx, u_ctx,
                          motion_keys, LWS_ARRAY_SIZE(motion_keys), motion_roi_callback);
-
-        u_ctx->s = 1;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1527,17 +1706,19 @@ signed char WS::motion_roi_callback(struct lejp_ctx *ctx, char reason)
 
     if ((reason & LEJP_FLAG_CB_IS_VALUE) && (reason == LEJPCB_VAL_NULL))
     {
-        std::strcat(ws_send_msg, "[");
+        u_ctx->message.append("[");
         for (int i = 0; i < cfg->motion.roi_count; i++)
         {
-            if ((u_ctx->flag & 4))
-                std::strcat(ws_send_msg, ",");
-            append_message(
-                "[%d,%d,%d,%d]", cfg->motion.rois[i].p0_x, cfg->motion.rois[i].p0_x, u_ctx->region.p0_y,
+            if ((u_ctx->flag & PNT_FLAG_SEPARATOR))
+                u_ctx->message.append(",");
+
+            append_session_msg(
+                u_ctx->message, "[%d,%d,%d,%d]", cfg->motion.rois[i].p0_x, cfg->motion.rois[i].p0_y,
                 cfg->motion.rois[i].p1_x, cfg->motion.rois[i].p1_y);
-            u_ctx->flag |= 4;
+            u_ctx->flag |= PNT_FLAG_SEPARATOR;
         }
-        std::strcat(ws_send_msg, "]");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("]");
         lejp_parser_pop(ctx);
     }
     else
@@ -1545,26 +1726,30 @@ signed char WS::motion_roi_callback(struct lejp_ctx *ctx, char reason)
         switch (reason)
         {
         case LEJPCB_ARRAY_START:
-            if ((u_ctx->flag & 4))
+            // not first, we need a separator
+            if (u_ctx->flag & PNT_FLAG_SEPARATOR)
             {
-                std::strcat(ws_send_msg, ",");
+                u_ctx->message.append(",");
             }
-            if ((u_ctx->flag & 1) != 1)
+            // is roi array open ? if so, open entry array
+            if (u_ctx->flag & PNT_FLAG_ROI_ARRAY)
             {
-                u_ctx->flag |= 1; // main array
-                u_ctx->midx = 0;  // main array index
-                std::strcat(ws_send_msg, "[");
+                u_ctx->flag |= PNT_FLAG_ROI_ENTRY; // entry array
+                u_ctx->vidx = 0;                   // entry array index
+                u_ctx->message.append("[");
             }
+            // roi array is not open ! open it
             else
             {
-                u_ctx->flag |= 2; // entry array
-                u_ctx->vidx = 0;  // entry array index
-                std::strcat(ws_send_msg, "[");
+                u_ctx->flag |= PNT_FLAG_ROI_ARRAY; // roi array
+                u_ctx->midx = 0;                   // roi array index
+                u_ctx->message.append("[");
             }
             break;
 
         case LEJPCB_VAL_NUM_INT:
-            if (u_ctx->flag & 2)
+            // parse roi entry with 4 elements
+            if (u_ctx->flag & PNT_FLAG_ROI_ENTRY)
             {
                 u_ctx->vidx++;
                 if (u_ctx->vidx == 1)
@@ -1587,16 +1772,23 @@ signed char WS::motion_roi_callback(struct lejp_ctx *ctx, char reason)
             break;
 
         case LEJPCB_ARRAY_END:
-            if (u_ctx->flag & 2)
+            // roi entry closed
+            if (u_ctx->flag & PNT_FLAG_ROI_ENTRY)
             {
-                u_ctx->flag ^= 2;
+                u_ctx->flag &= ~PNT_FLAG_ROI_ENTRY;
+
+                // we read 4 roi values add to message
                 if (u_ctx->vidx >= 4)
                 {
-                    append_message(
-                        "%d,%d,%d,%d", u_ctx->region.p0_x, u_ctx->region.p0_y, u_ctx->region.p1_x, u_ctx->region.p1_y);
+                    append_session_msg(
+                        u_ctx->message, "%d,%d,%d,%d", u_ctx->region.p0_x, u_ctx->region.p0_y, u_ctx->region.p1_x, u_ctx->region.p1_y);
                 }
-                std::strcat(ws_send_msg, "]");
-                u_ctx->flag |= 4;
+                u_ctx->message.append("]");
+
+                // roi entry parsed
+                u_ctx->flag |= PNT_FLAG_SEPARATOR;
+
+                // read up to 52 roi entries into u_ctx->region
                 if (u_ctx->midx <= 52)
                 {
                     cfg->motion.rois[u_ctx->midx] =
@@ -1604,11 +1796,12 @@ signed char WS::motion_roi_callback(struct lejp_ctx *ctx, char reason)
                     u_ctx->midx++;
                 }
             }
-            else if (u_ctx->flag & 1)
+            // roi main array closed
+            else if (u_ctx->flag & PNT_FLAG_ROI_ARRAY)
             {
-                u_ctx->flag ^= 1;
+                u_ctx->flag |= PNT_FLAG_SEPARATOR;
                 cfg->motion.roi_count = u_ctx->midx;
-                std::strcat(ws_send_msg, "]");
+                u_ctx->message.append("]");
                 lejp_parser_pop(ctx);
             }
             break;
@@ -1619,38 +1812,41 @@ signed char WS::motion_roi_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::info_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
-
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", info_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", info_keys[ctx->path_match - 1]);
 
         switch (ctx->path_match)
         {
         case PNT_INFO_IMP_SYSTEM_VERSION:
-            IMPVersion impVersion;
-            int ret = IMP_System_GetVersion(&impVersion);
-            if (ret)
             {
-                append_message(
-                    "\"%s\"", impVersion.aVersion);
-            }
-            else
-            {
-                append_message(
-                    "\"%s\"", "error");
+                IMPVersion impVersion;
+                int ret = IMP_System_GetVersion(&impVersion);
+                if (ret)
+                {
+                    append_session_msg(
+                        u_ctx->message, "\"%s\"", impVersion.aVersion);
+                }
+                else
+                {
+                    append_session_msg(
+                        u_ctx->message, "\"%s\"", "error");
+                }
             }
             break;
+        default:
+            u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+            break;               
         }
-
-        u_ctx->s = 1;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1659,42 +1855,56 @@ signed char WS::info_callback(struct lejp_ctx *ctx, char reason)
 
 signed char WS::action_callback(struct lejp_ctx *ctx, char reason)
 {
+    struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
+
     if (reason & LEJP_FLAG_CB_IS_VALUE && ctx->path_match)
     {
-
-        struct user_ctx *u_ctx = (struct user_ctx *)ctx->user;
         u_ctx->path = u_ctx->root + "." + std::string(ctx->path);
 
-        append_message(
-            "%s\"%s\":", u_ctx->s ? "," : "", action_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", action_keys[ctx->path_match - 1]);
 
         switch (ctx->path_match)
         {
         case PNT_RESTART_THREAD:
             if (reason == LEJPCB_VAL_NUM_INT)
             {
-                u_ctx->signal = atoi(ctx->buf);
+                int thread_restart = atoi(ctx->buf);
+                if (thread_restart & PNT_THREAD_RTSP)
+                {
+                    u_ctx->flag |= PNT_FLAG_RESTART_RTSP;
+                }
+                if (thread_restart & PNT_THREAD_VIDEO)
+                {
+                    u_ctx->flag |= PNT_FLAG_RESTART_VIDEO;
+                }
+                if (thread_restart & PNT_THREAD_AUDIO)
+                {
+                    u_ctx->flag |= PNT_FLAG_RESTART_AUDIO;
+                }
             }
-            append_message(
-                "\"%s\"", "initiated");
+            append_session_msg(
+                u_ctx->message, "\"%s\"", "initiated");
             break;
         case PNT_SAVE_CONFIG:
             cfg->updateConfig();
-            append_message(
-                "\"%s\"", "initiated");
+            append_session_msg(
+                u_ctx->message, "\"%s\"", "initiated");
             break;
         case PNT_CAPTURE:
-            u_ctx->signal = 32;
-            append_message(
-                "\"%s\"", "initiated");
+            u_ctx->flag |= PNT_FLAG_WS_REQUEST_PREVIEW;
+            append_session_msg(
+                u_ctx->message, "\"%s\"", "initiated");
             break;
+        default:
+            u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
+            break;               
         }
-
-        u_ctx->s = 1;
     }
     else if (reason == LEJPCB_OBJECT_END)
     {
-        std::strcat(ws_send_msg, "}");
+        u_ctx->flag |= PNT_FLAG_SEPARATOR;
+        u_ctx->message.append("}");
         lejp_parser_pop(ctx);
     }
 
@@ -1709,10 +1919,10 @@ signed char WS::root_callback(struct lejp_ctx *ctx, char reason)
         u_ctx->path.clear();
         u_ctx->root = ctx->path;
 
-        append_message(
-            "%s\"%s\":{", u_ctx->s ? "," : "", root_keys[ctx->path_match - 1]);
+        append_session_msg(
+            u_ctx->message, "%s\"%s\":{", (u_ctx->flag & PNT_FLAG_SEPARATOR) ? "," : "", root_keys[ctx->path_match - 1]);
 
-        u_ctx->s = 0;
+        u_ctx->flag &= ~PNT_FLAG_SEPARATOR;
 
         switch (ctx->path_match)
         {
@@ -1735,19 +1945,19 @@ signed char WS::root_callback(struct lejp_ctx *ctx, char reason)
 
 #if defined(AUDIO_SUPPORT)
         case PNT_AUDIO:
-            u_ctx->flag = global_audio[0]->aiChn;
+            u_ctx->value = global_audio[0]->aiChn;
             lejp_parser_push(ctx, u_ctx,
                              audio_keys, LWS_ARRAY_SIZE(audio_keys), audio_callback);
             break;
 #endif
 
         case PNT_STREAM0:
-            u_ctx->flag = global_video[0]->encChn;
+            u_ctx->value = global_video[0]->encChn;
             lejp_parser_push(ctx, &u_ctx,
                              stream_keys, LWS_ARRAY_SIZE(stream_keys), stream_callback);
             break;
         case PNT_STREAM1:
-            u_ctx->flag = global_video[1]->encChn;
+            u_ctx->value = global_video[1]->encChn;
             lejp_parser_push(ctx, &u_ctx,
                              stream_keys, LWS_ARRAY_SIZE(stream_keys), stream_callback);
             break;
@@ -1773,39 +1983,70 @@ signed char WS::root_callback(struct lejp_ctx *ctx, char reason)
     return 0;
 }
 
+void restart_threads_by_signal(int &flag)
+{
+
+    // inform main to restart threads
+    std::unique_lock lck(mutex_main);
+    if ((flag & PNT_FLAG_RESTART_RTSP) || (flag & PNT_FLAG_RESTART_VIDEO) || (flag & PNT_FLAG_RESTART_AUDIO))
+    {
+        if (flag & PNT_FLAG_RESTART_RTSP)
+        {
+            global_restart_rtsp = true;
+            flag &= ~PNT_FLAG_RESTART_RTSP;
+        }
+        if (flag & PNT_FLAG_RESTART_VIDEO)
+        {
+            global_restart_video = true;
+            flag &= ~PNT_FLAG_RESTART_VIDEO;
+        }
+        if (flag & PNT_FLAG_RESTART_AUDIO)
+        {
+            global_restart_audio = true;
+            flag &= ~PNT_FLAG_RESTART_AUDIO;
+        }
+        global_cv_worker_restart.notify_one();
+    }
+}
+
+std::string generateSessionID()
+{
+    std::random_device rd;
+    std::mt19937_64 eng(rd());
+    std::uniform_int_distribution<uint64_t> distr;
+    uint64_t randomValue = distr(eng);
+    auto timeStamp = std::time(nullptr);
+    std::stringstream ss;
+    ss << std::hex << randomValue << timeStamp;
+    return ss.str();
+}
+
+static void
+send_snapshot(lws_sorted_usec_list_t *sul)
+{
+    struct user_ctx *u_ctx = lws_container_of(sul, struct user_ctx, sul);
+    u_ctx->flag |= PNT_FLAG_WS_SEND_PREVIEW;
+    lws_callback_on_writable(u_ctx->wsi);
+}
+
 int WS::ws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len)
 {
     struct lejp_ctx ctx;
-
-    user_ctx *u_ctx = (user_ctx *)lws_context_user(lws_get_context(wsi));
-    u_ctx->s = 0;
+    user_ctx *u_ctx = (struct user_ctx *)user;
 
     char client_ip[128];
     lws_get_peer_simple(wsi, client_ip, sizeof(client_ip));
 
+    char *url_ptr;
     int url_length;
     int request_method;
-    int ws_send_msg_length;
-    char *url_ptr;
+
+    // security token ?token=
     char url_token[128]{0};
     char content_type[128]{0};
     std::string json_data((char *)in, len);
 
-    if (reason == LWS_CALLBACK_ESTABLISHED || reason == LWS_CALLBACK_HTTP)
-    {
-        // check if security is required and validate token
-        url_length = lws_get_urlarg_by_name_safe(wsi, "token", url_token, sizeof(url_token));
-
-        if (strcmp(token, url_token) != 0)
-        {
-            LOG_DEBUG("Unauthenticated websocket connect from: " << client_ip);
-            if (cfg->websocket.secured)
-            {
-                LOG_DEBUG("Connection refused.");
-                return -1;
-            }
-        }
-    }
+    //LOG_DDEBUG(reason);
 
     // get url and method
     if (reason >= LWS_CALLBACK_HTTP && reason <= LWS_CALLBACK_HTTP_WRITEABLE)
@@ -1816,202 +2057,364 @@ int WS::ws_callback(struct lws *wsi, enum lws_callback_reasons reason, void *use
 
     switch (reason)
     {
-    case LWS_CALLBACK_RECEIVE:
-        LOG_DDEBUG("LWS_CALLBACK_RECEIVE " << client_ip << ", " << json_data);
+    // ############################ WEBSOCKET ###############################
+    case LWS_CALLBACK_ESTABLISHED:
+        LOG_DDEBUG("LWS_CALLBACK_ESTABLISHED, ip:" << client_ip);
 
-        // cleanup response buffer
-        memset(ws_send_msg, 0, sizeof(ws_send_msg));
-
-        std::strcat(ws_send_msg, "{"); // start response json
-        lejp_construct(&ctx, root_callback, u_ctx, root_keys, LWS_ARRAY_SIZE(root_keys));
-        lejp_parse(&ctx, (uint8_t *)json_data.c_str(), json_data.length());
-        lejp_destruct(&ctx);
-        std::strcat(ws_send_msg, "}"); // close response json
-
-
-
+        // check if security is required and validate token
+        url_length = lws_get_urlarg_by_name_safe(wsi, "token", url_token, sizeof(url_token));
+        if (strcmp(token, url_token) == 0 || (strcmp(cfg->websocket.usertoken, "") != 0 && strcmp(cfg->websocket.usertoken, url_token) == 0))
         {
-            std::unique_lock lck(mutex_main);
-            // inform main to restart threads
-            if ((u_ctx->signal & PNT_THREAD_RTSP) || (u_ctx->signal & PNT_THREAD_VIDEO) || (u_ctx->signal & PNT_THREAD_AUDIO))
+            /* initialize new u_ctx session structure.
+             * assign current wsi and a new sessionid
+             */
+            new (user) user_ctx(generateSessionID(), wsi);
+        }
+        else
+        {
+            LOG_DEBUG("Unauthenticated websocket connect from: " << client_ip);
+            if (cfg->websocket.ws_secured)
             {
-                if (u_ctx->signal & PNT_THREAD_RTSP)
-                {
-                    global_restart_rtsp = true;
-                }
-                if (u_ctx->signal & PNT_THREAD_VIDEO)
-                {
-                    global_restart_video = true;
-                }
-                if (u_ctx->signal & PNT_THREAD_AUDIO)
-                {
-                    global_restart_audio = true;
-                }
-                global_cv_worker_restart.notify_one();
+                LOG_DEBUG("Connection refused.");
+                return -1;
             }
         }
+        break;
 
+    case LWS_CALLBACK_RECEIVE:
+        LOG_DDEBUG("LWS_CALLBACK_RECEIVE " << 
+            " id:" << u_ctx->id << 
+            " ,flag:" << u_ctx->flag << 
+            " ,ip:" << client_ip << 
+            " ,len:" << len << 
+            " ,last:" << lws_is_final_fragment(wsi));
 
-        lws_callback_on_writable(wsi);
+        /* larger requests can be segmented into several requests, 
+         * so we have to collect all the data until we reach the last segment.
+         * On receiving the first segment we should clear the rx_message
+         */
+        if(lws_is_first_fragment(wsi))
+            u_ctx->rx_message.clear();
+
+        u_ctx->rx_message.append(json_data);
+
+        if(!lws_is_final_fragment(wsi))
+            return 0;    
+
+        LOG_DDEBUG("u_ctx->rx_message: " << u_ctx->rx_message);
+
+        // set request pending
+        //u_ctx->flag |= PNT_FLAG_WS_REQUEST_PENDING;
+
+        // parse json and write response into u_ctx->message
+        u_ctx->message = "{";               // open response json 
+        lejp_construct(&ctx, root_callback, u_ctx, root_keys, LWS_ARRAY_SIZE(root_keys));
+        lejp_parse(&ctx, (uint8_t *)u_ctx->rx_message.c_str(), u_ctx->rx_message.length());
+        lejp_destruct(&ctx);
+        u_ctx->message.append("}");         // close response json
+        u_ctx->rx_message.clear();          // cleanup received data
+        u_ctx->flag &= ~PNT_FLAG_SEPARATOR; // always reset separator after parsing
+
+        // restart threads if required
+        restart_threads_by_signal(u_ctx->flag);
+
+        // incoming snapshot request via websocket
+        if (u_ctx->flag & PNT_FLAG_WS_REQUEST_PREVIEW)
+        {
+            // clenaup request flag
+            u_ctx->flag &= ~PNT_FLAG_WS_REQUEST_PREVIEW;
+
+            // drop overlapping image requests
+            if(u_ctx->flag & PNT_FLAG_WS_PREVIEW_PENDING) {
+                LOG_DDEBUG("drop overlapping image request.");
+                return 0;
+            };
+
+            // set prview pending flag 
+            u_ctx->flag |= PNT_FLAG_WS_PREVIEW_PENDING;
+
+            /* 'first_request_delay'
+             * first request after thread sleep should be a bit delayed, because the first
+             * images after wakup can be incomplete or having osd missed
+             * a default of 100 milliseconds should delay ~3 images
+             */
+            int first_request_delay = 0;
+            u_ctx->snapshot.r++;
+            global_jpeg[0]->subscribers++;
+
+            /* if the jpeg channel is inactive we need to start him
+             * this can also cause that required video channel also
+             * must been started
+             */
+            if (!global_jpeg[0]->active)
+            {
+                first_request_delay = cfg->websocket.first_image_delay * 1000;
+                global_jpeg[0]->should_grab_frames.notify_all();
+                global_jpeg[0]->is_activated.acquire();
+            }
+
+            auto now = steady_clock::now();
+            auto dur = duration_cast<milliseconds>(now - u_ctx->snapshot.last_snapshot_request).count();
+
+            /* Throttling to prevent images from being sent faster than they are created
+             * 'u_ctx->snapshot.throttle' is calculated to delay sendings
+             */
+            if (dur > 1000)
+            {
+                u_ctx->snapshot.rps = u_ctx->snapshot.r;
+                u_ctx->snapshot.r = 0;
+
+                if (u_ctx->snapshot.throttle > 100)
+                {
+                    u_ctx->snapshot.throttle = 100;
+                }
+                else if (u_ctx->snapshot.throttle < 1)
+                {
+                    u_ctx->snapshot.throttle = 1;
+                }
+
+                u_ctx->snapshot.throttle +=
+                    global_jpeg[0]->stream->stats.fps - u_ctx->snapshot.rps;
+                u_ctx->snapshot.last_snapshot_request = now;
+
+                LOG_DDEBUG("RPS: " << u_ctx->snapshot.rps << " " << u_ctx->snapshot.throttle << " " << dur);
+            }
+            
+            lws_sul_schedule(lws_get_context(wsi), 0, &u_ctx->sul, send_snapshot,
+                             (LWS_USEC_PER_SEC / (global_jpeg[0]->stream->stats.fps + u_ctx->snapshot.throttle)) + first_request_delay);
+
+            // send response for the image request 
+            u_ctx->tx_message = u_ctx->message;
+            lws_callback_on_writable(wsi);                             
+        } else {
+
+            // send response for all 'non image request' json requests
+            u_ctx->tx_message = u_ctx->message;
+            lws_callback_on_writable(wsi);
+        }
+
         break;
 
     case LWS_CALLBACK_SERVER_WRITEABLE:
-        LOG_DDEBUG("LWS_CALLBACK_SERVER_WRITEABLE");
+        LOG_DDEBUG("LWS_CALLBACK_SERVER_WRITEABLE id:" << u_ctx->id << ", ip:" << client_ip);
 
-        ws_send_msg_length = strlen(ws_send_msg);
-        if (ws_send_msg_length)
+        // send response message
+        if (!u_ctx->tx_message.empty())
         {
-            LOG_DDEBUG("TO " << client_ip << ":  " << ws_send_msg);
-            lws_write(wsi, (unsigned char *)ws_send_msg, ws_send_msg_length, LWS_WRITE_TEXT);
-            memset(ws_send_msg, 0, sizeof(ws_send_msg));
+            LOG_DDEBUG("u_ctx->tx_message: " << u_ctx->tx_message);
+            lws_write(wsi, (unsigned char *)u_ctx->tx_message.c_str(), u_ctx->tx_message.length(), LWS_WRITE_TEXT);
+            u_ctx->tx_message.clear();
         }
 
-        // send jpeg image via websocket
-        if ((u_ctx->signal & 32))
+        // delayed snapshot request via websocket, sending the image
+        if (u_ctx->flag & PNT_FLAG_WS_SEND_PREVIEW)
         {
-            send_jpeg(wsi);
-            memset(ws_send_msg, 0, sizeof(ws_send_msg));
+            global_jpeg[0]->subscribers--;
+            std::vector<unsigned char> jpeg_buf;
+            if (get_snapshot(jpeg_buf))
+            {
+                lws_write(wsi, jpeg_buf.data() + LWS_PRE, jpeg_buf.size() - LWS_PRE, LWS_WRITE_BINARY);
+            }
+            u_ctx->flag &= ~(PNT_FLAG_WS_SEND_PREVIEW | PNT_FLAG_WS_PREVIEW_PENDING);
         }
 
-        // always reset signal
-        u_ctx->signal = 0;
-        
+        // cleanup request pending flag
+        //u_ctx->flag &= ~PNT_FLAG_WS_REQUEST_PENDING;
         break;
 
     case LWS_CALLBACK_CLOSED:
-        LOG_DDEBUG("LWS_CALLBACK_CLOSED " << client_ip);
+        LOG_DDEBUG("LWS_CALLBACK_CLOSED id:" << u_ctx->id << ", ip:" << client_ip << ", flag:" << u_ctx->flag);
+
+        // cleanup delete possibly existing shedules for this session    
+        lws_sul_cancel(&u_ctx->sul);
+
+        // decrease jpeg subscribers if sending preview was sheduled
+        if(u_ctx->flag & PNT_FLAG_WS_PREVIEW_PENDING) {
+            global_jpeg[0]->subscribers--;
+        }
         break;
 
-    case LWS_CALLBACK_HTTP:
-        LOG_DDEBUG("LWS_CALLBACK_HTTP " << client_ip << " url:" << (char *)url_ptr << " method:" << request_method);
 
-        // http get
+    // ############################ HTTP ###############################
+    case LWS_CALLBACK_HTTP:
+        LOG_DDEBUG("LWS_CALLBACK_HTTP ip:" << client_ip << " url:" << (char *)url_ptr << " method:" << request_method);
+
+        // check if security is required and validate token
+        url_length = lws_get_urlarg_by_name_safe(wsi, "token", url_token, sizeof(url_token));
+        if (strcmp(token, url_token) == 0 || (strcmp(cfg->websocket.usertoken, "") != 0 && strcmp(cfg->websocket.usertoken, url_token) == 0))
+        {
+            /* initialize new u_ctx session structure.
+            * assign current wsi and a new sessionid
+            ' don't know if we need it for http
+            */
+            new (user) user_ctx(generateSessionID(), wsi);
+        }
+        else
+        {
+            LOG_DEBUG("Unauthenticated http connect from: " << client_ip);
+            if (cfg->websocket.http_secured)
+            {
+                LOG_DEBUG("Connection refused.");
+                if (lws_return_http_status(wsi,
+                                           HTTP_STATUS_FORBIDDEN, NULL) ||
+                    lws_http_transaction_completed(wsi))
+                    ;
+                return -1;
+            }
+        }
+
+        // http GET
         if (request_method == 0)
         {
             // Send preview image
             if (strcmp(url_ptr, "/preview.jpg") == 0)
             {
-                u_ctx->flag |= 128;
+                u_ctx->flag |= PNT_FLAG_HTTP_SEND_PREVIEW;
+                global_jpeg[0]->subscribers++;
+
+                if (!global_jpeg[0]->active)
+                {
+                    global_jpeg[0]->should_grab_frames.notify_all();
+                    global_jpeg[0]->is_activated.acquire();
+                    /* we need this delay to grab a valid image when stream resume from sleep
+                     * usleep is a bad choice, but lws_sul_schedule won't work as expected here
+                     * hopfully we find a better solution later
+                     */
+                    usleep(cfg->websocket.first_image_delay * 1000);
+                }
+
+                global_jpeg[0]->subscribers--;
                 lws_callback_on_writable(wsi);
                 return 0;
             }
         }
-        // http post
+        // http POST
         else if (request_method == 1)
         {
             // get content length
             if (strcmp(url_ptr, "/json") == 0 && strcmp(content_type, "application/json") == 0)
             {
-                u_ctx->flag |= 256;
                 // Read content length header and store received data
                 char length_str[16];
                 if (lws_hdr_copy(wsi, length_str, sizeof(length_str), WSI_TOKEN_HTTP_CONTENT_LENGTH) > 0)
                 {
-                    u_ctx->post_data_size = atoi(length_str);
+                    if (atoi(length_str))
+                    {
+                        u_ctx->flag |= PNT_FLAG_HTTP_RECEIVED_MESSAGE;
+                    }
                 }
                 return 0;
             }
         }
 
         // not implemented
-        {
-            const char *response = "HTTP/1.1 501 Not Implemented\r\nContent-Type: text/plain\r\n\r\n";
-            lws_write(wsi, (unsigned char *)response, strlen(response), LWS_WRITE_HTTP);
-            return -1;
-        }
+        u_ctx->flag |= PNT_FLAG_HTTP_SEND_INVALID;
+        lws_callback_on_writable(wsi);
+        return 0;
         break;
 
     case LWS_CALLBACK_HTTP_BODY:
-        LOG_DDEBUG("LWS_CALLBACK_HTTP_BODY " << client_ip);
+        LOG_DDEBUG("LWS_CALLBACK_HTTP_BODY ip:" << client_ip);
+        u_ctx->rx_message.append(json_data);
+        break;
 
-        if (u_ctx->post_data_size)
+    case LWS_CALLBACK_HTTP_BODY_COMPLETION: //LWS_CALLBACK_HTTP_BODY:
+        LOG_DDEBUG("LWS_CALLBACK_HTTP_BODY ip:" << client_ip << ", data:" << u_ctx->rx_message);
+
+        if (u_ctx->flag & PNT_FLAG_HTTP_RECEIVED_MESSAGE)
         {
-            // cleanup response buffer
-            memset(ws_send_msg, 0, sizeof(ws_send_msg));
-
-            std::strcat(ws_send_msg, "{"); // start response json
+            // parse json and write response into u_ctx->message
+            u_ctx->message = "{";               // open response json
             lejp_construct(&ctx, root_callback, u_ctx, root_keys, LWS_ARRAY_SIZE(root_keys));
-            lejp_parse(&ctx, (uint8_t *)json_data.c_str(), json_data.length());
+            lejp_parse(&ctx, (uint8_t *)u_ctx->rx_message.c_str(), u_ctx->rx_message.length());
             lejp_destruct(&ctx);
-            std::strcat(ws_send_msg, "}"); // close response json
-            u_ctx->flag |= 256;
+            u_ctx->message.append("}");         // close response json
+            u_ctx->rx_message.clear();          // cleanup received data
+            u_ctx->flag &= ~PNT_FLAG_SEPARATOR; // always reset separator after parsing
+            u_ctx->flag |= PNT_FLAG_HTTP_SEND_MESSAGE;
 
-            {
-                std::unique_lock lck(mutex_main);
-                // inform main to restart threads
-                if ((u_ctx->signal & PNT_THREAD_RTSP) || (u_ctx->signal & PNT_THREAD_VIDEO) || (u_ctx->signal & PNT_THREAD_AUDIO))
-                {
-                    if (u_ctx->signal & PNT_THREAD_RTSP)
-                    {
-                        global_restart_rtsp = true;
-                    }
-                    if (u_ctx->signal & PNT_THREAD_VIDEO)
-                    {
-                        global_restart_video = true;
-                    }
-                    if (u_ctx->signal & PNT_THREAD_AUDIO)
-                    {
-                        global_restart_audio = true;
-                    }
-                    global_cv_worker_restart.notify_one();
-                }
-            }
+            /* copy response into u_ctx->message into u_ctx->tx_message
+             * can be helpfull to handle overlapping requests in future
+             */ 
+            u_ctx->tx_message = u_ctx->message;
+            u_ctx->tx_message.clear();
 
-            // always reset signal
-            u_ctx->signal = 0;
+            // send response
             lws_callback_on_writable(wsi);
+
+            // restart threads if requested
+            restart_threads_by_signal(u_ctx->flag);
+
             return 0;
         }
         break;
 
     case LWS_CALLBACK_HTTP_WRITEABLE:
-        LOG_DDEBUG("LWS_CALLBACK_HTTP_WRITEABLE " << client_ip << " " << (int)u_ctx->flag);
+        LOG_DDEBUG("LWS_CALLBACK_HTTP_WRITEABLE ip:" << client_ip << " " << (int)u_ctx->flag);
 
-        if (u_ctx->flag & 128)
         {
-            u_ctx->flag &= ~128;
-            LOG_DDEBUG("/preview.jpg " << u_ctx->flag);
+            uint8_t header[LWS_PRE + 1024];
+            memset(header, 0, sizeof(header));
+            uint8_t *start = &header[LWS_PRE];
+            uint8_t *p = &header[LWS_PRE];
+            uint8_t *end = &header[sizeof(header) - 1];
 
-            // create and send preview image
-            std::vector<uint8_t> jpeg_data = Worker::capture_jpeg_image(2);
-            size_t jpeg_size = jpeg_data.size();
-
-            // format image to send via libwebsockets
-            std::vector<unsigned char> jpeg_buf(LWS_PRE + jpeg_size);
-            memcpy(jpeg_buf.data() + LWS_PRE, jpeg_data.data(), jpeg_size);
-
-            // Prepare the HTTP headers
-            std::string headers = "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: " + std::to_string(jpeg_size) + "\r\n\r\n";
-            lws_write(wsi, (unsigned char *)headers.c_str(), headers.size(), LWS_WRITE_HTTP);
-
-            // Write image
-            lws_write(wsi, jpeg_buf.data() + LWS_PRE, jpeg_size, LWS_WRITE_HTTP);
-            lws_callback_on_writable(wsi);
-        }
-
-        if (u_ctx->flag & 256)
-        {
-            u_ctx->flag &= ~256;
-            LOG_DDEBUG("/json " << u_ctx->flag);
-
-            ws_send_msg_length = strlen(ws_send_msg);
-            if (ws_send_msg_length)
+            if (u_ctx->flag & PNT_FLAG_HTTP_SEND_PREVIEW)
             {
-                LOG_DDEBUG("TO " << client_ip << ":  " << ws_send_msg);
+                u_ctx->flag &= ~PNT_FLAG_HTTP_SEND_PREVIEW;
 
-                // Prepare the HTTP headers
-                std::string headers = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " + std::to_string(ws_send_msg_length) + "\r\n\r\n";
-                lws_write(wsi, (unsigned char *)headers.c_str(), headers.size(), LWS_WRITE_HTTP);
+                // Write image
+                std::vector<unsigned char> jpeg_buf;
+                if (get_snapshot(jpeg_buf))
+                {
+                    if (lws_add_http_common_headers(wsi, HTTP_STATUS_OK, "image/jpeg", jpeg_buf.size() - LWS_PRE, &p, end) ||
+                        lws_finalize_write_http_header(wsi, start, &p, end) ||
+                        !lws_write(wsi, jpeg_buf.data() + LWS_PRE, jpeg_buf.size() - LWS_PRE, LWS_WRITE_BINARY) ||
+                        lws_http_transaction_completed(wsi))
+                    {
 
-                // write json response
-                lws_write(wsi, (unsigned char *)ws_send_msg, ws_send_msg_length, LWS_WRITE_TEXT);
-                memset(ws_send_msg, 0, sizeof(ws_send_msg));
+                        LOG_ERROR("lws error sending image");
+                        return 1;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                }
             }
 
-            if (lws_http_transaction_completed(wsi) != 0)
+            if (u_ctx->flag & PNT_FLAG_HTTP_SEND_MESSAGE)
+            {
+                u_ctx->flag &= ~PNT_FLAG_HTTP_SEND_MESSAGE;
+                LOG_DDEBUG("/json " << u_ctx->flag);
+                if (!u_ctx->message.empty())
+                {
+                    LOG_DDEBUG("TO " << client_ip << ":  " << u_ctx->message);
+
+                    // Prepare the HTTP headers
+                    if (lws_add_http_common_headers(wsi, HTTP_STATUS_OK, "application/json", u_ctx->message.length(), &p, end) ||
+                        lws_finalize_write_http_header(wsi, start, &p, end) ||
+                        !lws_write(wsi, (unsigned char *)u_ctx->message.c_str(), u_ctx->message.length(), LWS_WRITE_TEXT) ||
+                        lws_http_transaction_completed(wsi))
+                    {
+
+                        LOG_ERROR("lws error sending response");
+                        return -1;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                }
+                return 0;
+            }
+
+            if (lws_add_http_common_headers(wsi, HTTP_STATUS_NOT_IMPLEMENTED, "text/plain", 0, &p, end) ||
+                lws_finalize_write_http_header(wsi, start, &p, end) ||
+                lws_http_transaction_completed(wsi))
             {
 
-                LOG_ERROR("lws_http_transaction_completed failed.");
+                LOG_ERROR("lws error sending not implemented");
             };
             return -1;
         }
@@ -2052,12 +2455,6 @@ void WS::start()
     info.protocols = &protocols;
     info.gid = -1;
     info.uid = -1;
-
-    // add current class instances to lws context
-    user_ctx u_ctx;
-    // u_ctx.ws = this;
-    u_ctx.s = 0;
-    info.user = &u_ctx;
 
     context = lws_create_context(&info);
 

--- a/src/WS.hpp
+++ b/src/WS.hpp
@@ -43,4 +43,5 @@ private:
         static signed char action_callback(struct lejp_ctx *ctx, char reason);
 };
 
+        static uint32_t global_session_id = 0;
 #endif

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -12,11 +12,6 @@
 #define NUM_AUDIO_CHANNELS 1
 #define NUM_VIDEO_CHANNELS 2
 
-/*
-    ToDo's
-    simplify msgChannel only vector required
-*/
-
 struct AudioFrame
 {
 	std::vector<uint8_t> data;
@@ -33,9 +28,14 @@ struct H264NALUnit
 struct jpeg_stream {
     int encChn;
     _stream* stream;
+    int subscribers{0};
     bool running;
+    bool active{false};
     pthread_t thread;
-    IMPEncoder * imp_encoder;
+    IMPEncoder * imp_encoder;   
+    std::condition_variable should_grab_frames;
+    std::binary_semaphore is_activated{0};
+
     jpeg_stream(int encChn, _stream* stream)
         : encChn(encChn), stream(stream), running(false), imp_encoder(nullptr) {}  
 };
@@ -44,6 +44,7 @@ struct audio_stream {
     int devId;
     int aiChn;
     bool running;
+    bool active{false};
     pthread_t thread;
     IMPAudio *imp_audio;
     std::shared_ptr<MsgChannel<AudioFrame>> msgChannel;
@@ -56,6 +57,7 @@ struct audio_stream {
     std::atomic<bool> hasDataCallback;
     std::mutex onDataCallbackLock;    // protects onDataCallback from deallocation
     std::condition_variable should_grab_frames;
+    std::binary_semaphore is_activated{0};
 
     audio_stream(int devId, int aiChn)
         : devId(devId), aiChn(aiChn), running(false), imp_audio(nullptr),
@@ -71,17 +73,21 @@ struct video_stream {
     pthread_t thread;
     bool idr;
     int idr_fix;
+    bool active{false};
     IMPEncoder *imp_encoder;
     IMPFramesource *imp_framesource;
     std::shared_ptr<MsgChannel<H264NALUnit>> msgChannel;
     std::function<void(void)> onDataCallback;
+    std::atomic<bool> run_for_jpeg;         // see comment in audio_stream
     std::atomic<bool> hasDataCallback;      // see comment in audio_stream
-    std::mutex onDataCallbackLock;    // protects onDataCallback from deallocation
+    std::mutex onDataCallbackLock;          // protects onDataCallback from deallocation
     std::condition_variable should_grab_frames;
+    std::binary_semaphore is_activated{0};
 
     video_stream(int encChn, _stream* stream, const char *name)
         : encChn(encChn), stream(stream), running(false), name(name), idr(false), imp_encoder(nullptr), imp_framesource(nullptr),
-          msgChannel(std::make_shared<MsgChannel<H264NALUnit>>(MSG_CHANNEL_SIZE)), onDataCallback(nullptr), idr_fix(0), hasDataCallback{false} {}
+          msgChannel(std::make_shared<MsgChannel<H264NALUnit>>(MSG_CHANNEL_SIZE)), onDataCallback(nullptr), idr_fix(0), run_for_jpeg{false}, 
+          hasDataCallback{false} {}
 };
 
 extern std::condition_variable global_cv_worker_restart;
@@ -96,7 +102,7 @@ extern bool global_main_thread_signal;
 extern bool global_motion_thread_signal; 
 extern char volatile global_rtsp_thread_signal; 
 
-extern std::shared_ptr<jpeg_stream> global_jpeg;
+extern std::shared_ptr<jpeg_stream> global_jpeg[NUM_VIDEO_CHANNELS];
 extern std::shared_ptr<audio_stream> global_audio[NUM_AUDIO_CHANNELS];
 extern std::shared_ptr<video_stream> global_video[NUM_VIDEO_CHANNELS];
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,16 +16,18 @@ using namespace std::chrono;
 std::mutex mutex_main;
 std::condition_variable global_cv_worker_restart;
 
-bool global_restart_rtsp = true;
-bool global_restart_video = true;
-bool global_restart_audio = true;
+bool startup = true;
+
+bool global_restart_rtsp = false;
+bool global_restart_video = false;
+bool global_restart_audio = false;
 
 bool global_osd_thread_signal = false;
 bool global_main_thread_signal = false;
 bool global_motion_thread_signal = false;
 char volatile global_rtsp_thread_signal{1};
 
-std::shared_ptr<jpeg_stream> global_jpeg = {nullptr};
+std::shared_ptr<jpeg_stream> global_jpeg[NUM_VIDEO_CHANNELS] = {nullptr};
 std::shared_ptr<video_stream> global_video[NUM_VIDEO_CHANNELS] = {nullptr};
 #if defined(AUDIO_SUPPORT)
 std::shared_ptr<audio_stream> global_audio[NUM_AUDIO_CHANNELS] = {nullptr};
@@ -93,7 +95,9 @@ int main(int argc, const char *argv[])
 
     global_video[0] = std::make_shared<video_stream>(0, &cfg->stream0, "stream0");
     global_video[1] = std::make_shared<video_stream>(1, &cfg->stream1, "stream1");
-    global_jpeg = std::make_shared<jpeg_stream>(jpeg_stream{2, &cfg->stream2});
+    global_jpeg[0] = std::make_shared<jpeg_stream>(2, &cfg->stream2);
+    //global_jpeg[1] = std::make_shared<jpeg_stream>(jpeg_stream{3, &cfg->stream3});
+
 #if defined(AUDIO_SUPPORT)
     global_audio[0] = std::make_shared<audio_stream>(1, 0);
 #endif
@@ -102,7 +106,7 @@ int main(int argc, const char *argv[])
 
     while (true)
     {
-        if (global_restart_video)
+        if (global_restart_video || startup)
         {
             if (cfg->stream0.enabled)
             {
@@ -117,7 +121,7 @@ int main(int argc, const char *argv[])
             if (cfg->stream2.enabled)
             {
                 StartHelper sh{2};
-                int ret = pthread_create(&global_jpeg->thread, nullptr, Worker::jpeg_grabber, static_cast<void *>(&sh));
+                int ret = pthread_create(&global_jpeg[0]->thread, nullptr, Worker::jpeg_grabber, static_cast<void *>(&sh));
                 LOG_DEBUG_OR_ERROR(ret, "create jpeg thread");
                 // wait for initialization done
                 sh.has_started.acquire();
@@ -138,7 +142,7 @@ int main(int argc, const char *argv[])
         global_restart_video = false;
 
 #if defined(AUDIO_SUPPORT)
-        if (cfg->audio.input_enabled && global_restart_audio)
+        if (cfg->audio.input_enabled && (global_restart_audio || startup))
         {
             StartHelper sh{0};
             int ret = pthread_create(&global_audio[0]->thread, nullptr, Worker::audio_grabber, static_cast<void *>(&sh));
@@ -150,12 +154,14 @@ int main(int argc, const char *argv[])
 #endif
 
         // start rtsp server
-        if (global_rtsp_thread_signal != 0 && global_restart_rtsp)
+        if (global_rtsp_thread_signal != 0 && (global_restart_rtsp || startup))
         {
             int ret = pthread_create(&rtsp_thread, nullptr, RTSP::run, &rtsp);
             LOG_DEBUG_OR_ERROR(ret, "create rtsp thread");
         }
         global_restart_rtsp = false;
+        
+        startup = false;
 
         LOG_DEBUG("main thread is going to sleep");
         std::unique_lock lck(mutex_main);
@@ -177,7 +183,6 @@ int main(int argc, const char *argv[])
 
         if (global_restart_video)
         {
-
             // stop motion thread
             if (global_motion_thread_signal)
             {
@@ -195,10 +200,11 @@ int main(int argc, const char *argv[])
             }
 
             // stop jpeg
-            if (global_jpeg->imp_encoder)
+            if (global_jpeg[0]->imp_encoder)
             {
-                global_jpeg->running = false;
-                int ret = pthread_join(global_jpeg->thread, NULL);
+                global_jpeg[0]->running = false;
+                global_jpeg[0]->should_grab_frames.notify_one();
+                int ret = pthread_join(global_jpeg[0]->thread, NULL);
                 LOG_DEBUG_OR_ERROR(ret, "join jpeg thread");
             }
 

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -419,7 +419,7 @@ void *Worker::stream_grabber(void *arg)
                 LOG_DDEBUG("IMP_Encoder_PollingStream(" << encChn << ", " << cfg->general.imp_polling_timeout << ") timeout !");
             }
         }
-        else if(global_video[encChn]->onDataCallback == nullptr && !global_restart_video && !global_video[encChn]->run_for_jpeg)
+        else if (global_video[encChn]->onDataCallback == nullptr && !global_restart_video && !global_video[encChn]->run_for_jpeg)
         {
             LOG_DDEBUG("VIDEO LOCK" << 
                        " channel:" << encChn << 

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -3,6 +3,8 @@
 
 #define MODULE "WORKER"
 
+using namespace std::chrono;
+
 unsigned long long tDiffInMs(struct timeval *startTime)
 {
     struct timeval currentTime;
@@ -14,76 +16,6 @@ unsigned long long tDiffInMs(struct timeval *startTime)
     unsigned long long milliseconds = (seconds * 1000) + (microseconds / 1000);
 
     return milliseconds;
-}
-
-std::vector<uint8_t> Worker::capture_jpeg_image(int encChn)
-{
-    std::vector<uint8_t> jpeg_data;
-    int ret = 0;
-
-    ret = IMP_Encoder_StartRecvPic(encChn);
-    if (ret != 0)
-    {
-        std::cerr << "IMP_Encoder_StartRecvPic(" << encChn << ") failed: " << strerror(errno) << std::endl;
-        return jpeg_data;
-    }
-
-    if (IMP_Encoder_PollingStream(encChn, 1000) == 0)
-    {
-
-        IMPEncoderStream stream;
-        if (IMP_Encoder_GetStream(encChn, &stream, GET_STREAM_BLOCKING) == 0)
-        {
-            int nr_pack = stream.packCount;
-
-            for (int i = 0; i < nr_pack; i++)
-            {
-                void *data_ptr;
-                size_t data_len;
-
-#if defined(PLATFORM_T31)
-                IMPEncoderPack *pack = &stream.pack[i];
-                uint32_t remSize = 0; // Declare remSize here
-                if (pack->length)
-                {
-                    remSize = stream.streamSize - pack->offset;
-                    data_ptr = (void *)((char *)stream.virAddr + ((remSize < pack->length) ? 0 : pack->offset));
-                    data_len = (remSize < pack->length) ? remSize : pack->length;
-                }
-                else
-                {
-                    continue; // Skip empty packs
-                }
-#elif defined(PLATFORM_T10) || defined(PLATFORM_T20) || defined(PLATFORM_T21) || defined(PLATFORM_T23) || defined(PLATFORM_T30)
-                data_ptr = reinterpret_cast<void *>(stream.pack[i].virAddr);
-                data_len = stream.pack[i].length;
-#endif
-
-                // Write data to vector
-                jpeg_data.insert(jpeg_data.end(), (uint8_t *)data_ptr, (uint8_t *)data_ptr + data_len);
-
-#if defined(PLATFORM_T31)
-                // Check the condition only under T31 platform, as remSize is used here
-                if (remSize && pack->length > remSize)
-                {
-                    data_ptr = (void *)((char *)stream.virAddr);
-                    data_len = pack->length - remSize;
-                    jpeg_data.insert(jpeg_data.end(), (uint8_t *)data_ptr, (uint8_t *)data_ptr + data_len);
-                }
-#endif
-            }
-
-            IMP_Encoder_ReleaseStream(encChn, &stream); // Release stream after saving
-        }
-    }
-
-    // ret = IMP_Encoder_StopRecvPic(encChn);
-    if (ret != 0)
-    {
-        std::cerr << "IMP_Encoder_StopRecvPic(" << encChn << ") failed: " << strerror(errno) << std::endl;
-    }
-
-    return jpeg_data;
 }
 
 static int save_jpeg_stream(int fd, IMPEncoderStream *stream)
@@ -143,37 +75,72 @@ void *Worker::jpeg_grabber(void *arg)
     LOG_DEBUG("Start jpeg_grabber thread.");
 
     StartHelper *sh = static_cast<StartHelper *>(arg);
-    int encChn = sh->encChn;
+    int jpgChn = sh->encChn - 2;
     int ret;
-    struct timeval ts;
-    gettimeofday(&ts, NULL);
+    uint32_t bps{0};
+    int delay{0};
+    uint32_t fps{(uint32_t)global_jpeg[jpgChn]->stream->fps};
+    int64_t auto_fps{(int64_t)((1000000/global_jpeg[jpgChn]->stream->fps) * 0.8)};
 
-    global_jpeg->imp_encoder = IMPEncoder::createNew(global_jpeg->stream, encChn, global_jpeg->stream->jpeg_channel, "stream2");
+    unsigned long long ms{0};
+    gettimeofday(&global_jpeg[jpgChn]->stream->stats.ts, NULL);
+    global_jpeg[jpgChn]->stream->stats.ts.tv_sec -= 10;
+
+    global_jpeg[jpgChn]->imp_encoder = IMPEncoder::createNew(
+        global_jpeg[jpgChn]->stream, sh->encChn, global_jpeg[jpgChn]->stream->jpeg_channel, "stream2");
 
     // inform main that initialization is complete
     sh->has_started.release();
 
-    ret = IMP_Encoder_StartRecvPic(global_jpeg->encChn);
-    LOG_DEBUG_OR_ERROR(ret, "IMP_Encoder_StartRecvPic(" << global_jpeg->encChn << ")");
+    ret = IMP_Encoder_StartRecvPic(global_jpeg[jpgChn]->encChn);
+    LOG_DEBUG_OR_ERROR(ret, "IMP_Encoder_StartRecvPic(" << global_jpeg[jpgChn]->encChn << ")");
     if (ret != 0)
         return 0;
 
-    global_jpeg->running = true;
-    while (global_jpeg->running)
+    global_jpeg[jpgChn]->active = true;
+    global_jpeg[jpgChn]->running = true;
+    while (global_jpeg[jpgChn]->running)
     {
-        if (tDiffInMs(&ts) > 1000)
+        /* 'delay'
+         * if the last request is handled, the counter is used to serve some additional images
+         * By this we can prevent unwanted suspends if less images requested than created
+         */ 
+        if (global_jpeg[jpgChn]->subscribers || delay)
         {
+            /* check if current jpeg channal is running if not start it
+             */
 
-            if (IMP_Encoder_PollingStream(global_jpeg->encChn, cfg->general.imp_polling_timeout) == 0)
+            if(!global_video[global_jpeg[jpgChn]->stream->jpeg_channel]->active) {
+                
+                /* required video channel was not running, we need to start it  
+                 * and set run_for_jpeg as a reason.
+                */
+                global_video[global_jpeg[jpgChn]->stream->jpeg_channel]->run_for_jpeg = true;
+                global_video[global_jpeg[jpgChn]->stream->jpeg_channel]->should_grab_frames.notify_one();
+                global_video[global_jpeg[jpgChn]->stream->jpeg_channel]->is_activated.acquire();
+            }
+
+            if(!global_jpeg[jpgChn]->subscribers && delay)
+                delay--;
+            else
+                delay = 25;
+
+            auto start_grab = steady_clock::now();
+
+            if (IMP_Encoder_PollingStream(global_jpeg[jpgChn]->encChn, cfg->general.imp_polling_timeout) == 0)
             {
-
                 IMPEncoderStream stream;
-                if (IMP_Encoder_GetStream(global_jpeg->encChn, &stream, GET_STREAM_BLOCKING) == 0)
+                if (IMP_Encoder_GetStream(global_jpeg[jpgChn]->encChn, &stream, GET_STREAM_BLOCKING) == 0)
                 {
+
+                    usleep(auto_fps);
+
+                    fps++;
+                    bps += stream.pack->length;
 
                     //  Check for success
                     const char *tempPath = "/tmp/snapshot.tmp";             // Temporary path
-                    const char *finalPath = global_jpeg->stream->jpeg_path; // Final path for the JPEG snapshot
+                    const char *finalPath = global_jpeg[jpgChn]->stream->jpeg_path; // Final path for the JPEG snapshot
 
                     // Open and create temporary file with read and write permissions
                     int snap_fd = open(tempPath, O_RDWR | O_CREAT | O_TRUNC, 0777);
@@ -210,24 +177,62 @@ void *Worker::jpeg_grabber(void *arg)
                         LOG_ERROR("Failed to open JPEG snapshot for writing: " << tempPath);
                     }
 
-                    IMP_Encoder_ReleaseStream(2, &stream); // Release stream after saving
+                    IMP_Encoder_ReleaseStream(global_jpeg[jpgChn]->encChn, &stream); // Release stream after saving
                 }
+
+                ms = tDiffInMs(&global_jpeg[jpgChn]->stream->stats.ts);
+                if (ms > 1000)
+                {
+                    if(fps > global_jpeg[jpgChn]->stream->fps && auto_fps < 1000000) {
+                        auto_fps += (fps - global_jpeg[jpgChn]->stream->fps) * (1000 / global_jpeg[jpgChn]->stream->fps);
+                    } else if(fps < global_jpeg[jpgChn]->stream->fps && auto_fps > 0) {
+                        auto_fps -= (global_jpeg[jpgChn]->stream->fps - fps) * (1000 / global_jpeg[jpgChn]->stream->fps);
+                    }
+
+                    global_jpeg[jpgChn]->stream->stats.fps = fps;
+                    global_jpeg[jpgChn]->stream->stats.bps = bps;
+                    fps = 0; bps = 0;
+                    gettimeofday(&global_jpeg[jpgChn]->stream->stats.ts, NULL);
+
+                    LOG_DDEBUG("JPG " << jpgChn << 
+                              " fps: " << global_jpeg[jpgChn]->stream->stats.fps << 
+                              " bps: " << global_jpeg[jpgChn]->stream->stats.bps <<
+                              " subscribers: " << global_jpeg[jpgChn]->subscribers <<
+                              " auto_fps: " << auto_fps <<
+                              " ms: " << ms);
+                }                
             }
-
-            gettimeofday(&ts, NULL);
         }
-        usleep(THREAD_SLEEP);
+        else
+        {
+            LOG_DDEBUG("JPEG LOCK" << 
+                       " channel:" << jpgChn);
+
+            global_jpeg[jpgChn]->stream->stats.bps = 0;
+            global_jpeg[jpgChn]->stream->stats.fps = 0;
+            global_jpeg[jpgChn]->active = false;
+            global_video[global_jpeg[jpgChn]->stream->jpeg_channel]->run_for_jpeg = false;
+            std::unique_lock<std::mutex> lock_stream{mutex_main};
+            while (!global_jpeg[jpgChn]->subscribers && !global_restart_video)
+                global_jpeg[jpgChn]->should_grab_frames.wait(lock_stream);
+
+            global_jpeg[jpgChn]->is_activated.release();
+            global_jpeg[jpgChn]->active = true;
+
+            LOG_DDEBUG("JPEG UNLOCK" << 
+                       " channel:" << jpgChn);            
+        }
     }
 
-    if (global_jpeg->imp_encoder)
+    if (global_jpeg[jpgChn]->imp_encoder)
     {
-        global_jpeg->imp_encoder->deinit();
+        global_jpeg[jpgChn]->imp_encoder->deinit();
 
-        delete global_jpeg->imp_encoder;
-        global_jpeg->imp_encoder = nullptr;
+        delete global_jpeg[jpgChn]->imp_encoder;
+        global_jpeg[jpgChn]->imp_encoder = nullptr;
     }
 
-    LOG_DEBUG_OR_ERROR(ret, "IMP_Encoder_StopRecvPic(" << global_jpeg->encChn << ")");
+    LOG_DEBUG_OR_ERROR(ret, "IMP_Encoder_StopRecvPic(" << global_jpeg[jpgChn]->encChn << ")");
 
     return 0;
 }
@@ -263,10 +268,24 @@ void *Worker::stream_grabber(void *arg)
     if (ret != 0)
         return 0;
 
+    /* 'active' indicates, the thread is activly polling and grabbing images
+     * 'running' describes the runlevel of the thread, if this value is set to false
+     *           the thread exits and cleanup all ressources 
+     */
+    global_video[encChn]->active = true;
     global_video[encChn]->running = true;
     while (global_video[encChn]->running)
     {
-        if (global_video[encChn]->hasDataCallback || global_video[encChn]->stream->power_saving == false)
+        /* bool helper to check if this is the active jpeg channel and a jpeg is requested while 
+         * the channel is inactive
+         */
+        bool run_for_jpeg = (encChn == global_jpeg[0]->stream->jpeg_channel && global_video[encChn]->run_for_jpeg);
+
+        /* now we need to verify that 
+         * 1. a client is connected (hasDataCallback)
+         * 2. a jpeg is requested 
+         */
+        if (global_video[encChn]->hasDataCallback || run_for_jpeg)
         {
             if (IMP_Encoder_PollingStream(encChn, cfg->general.imp_polling_timeout) == 0)
             {
@@ -361,15 +380,21 @@ void *Worker::stream_grabber(void *arg)
 
                 IMP_Encoder_ReleaseStream(encChn, &stream);
 
-                ms = tDiffInMs(&global_video[encChn]->stream->osd.stats.ts);
+                ms = tDiffInMs(&global_video[encChn]->stream->stats.ts);
                 if (ms > 1000)
                 {
-                    global_video[encChn]->stream->osd.stats.bps = ((bps * 8) * 1000 / ms) / 1000;
-                    bps = 0;
-                    global_video[encChn]->stream->osd.stats.fps = fps * 1000 / ms;
-                    fps = 0;
-                    gettimeofday(&global_video[encChn]->stream->osd.stats.ts, NULL);
 
+                    /* currently we write into osd and stream stats,
+                     * osd will be removed and redesigned in future
+                    */
+                    global_video[encChn]->stream->stats.bps = bps;
+                    global_video[encChn]->stream->osd.stats.bps = bps;
+                    global_video[encChn]->stream->stats.fps = fps;
+                    global_video[encChn]->stream->osd.stats.fps = fps;
+
+                    fps = 0; bps = 0;
+                    gettimeofday(&global_video[encChn]->stream->stats.ts, NULL);
+                    global_video[encChn]->stream->osd.stats.ts = global_video[encChn]->stream->stats.ts;
                     /*
                     IMPEncoderCHNStat encChnStats;
                     IMP_Encoder_Query(channel->encChn, &encChnStats);
@@ -394,13 +419,28 @@ void *Worker::stream_grabber(void *arg)
                 LOG_DDEBUG("IMP_Encoder_PollingStream(" << encChn << ", " << cfg->general.imp_polling_timeout << ") timeout !");
             }
         }
-        else
+        else if(global_video[encChn]->onDataCallback == nullptr && !global_restart_video && !global_video[encChn]->run_for_jpeg)
         {
+            LOG_DDEBUG("VIDEO LOCK" << 
+                       " channel:" << encChn << 
+                       " hasCallbackIsNull:" << (global_video[encChn]->onDataCallback == nullptr) << 
+                       " restartVideo:" << global_restart_video << 
+                       " runForJpeg:" << global_video[encChn]->run_for_jpeg);
+
+            global_video[encChn]->stream->stats.bps = 0;
+            global_video[encChn]->stream->stats.fps = 0;
             global_video[encChn]->stream->osd.stats.bps = 0;
-            global_video[encChn]->stream->osd.stats.fps = 1;
+            global_video[encChn]->stream->osd.stats.fps = 0;
+            global_video[encChn]->active = false;
             std::unique_lock<std::mutex> lock_stream{mutex_main};
-            while (global_video[encChn]->onDataCallback == nullptr && !global_restart_video)
+            while (global_video[encChn]->onDataCallback == nullptr && !global_restart_video && !global_video[encChn]->run_for_jpeg)
                 global_video[encChn]->should_grab_frames.wait(lock_stream);
+
+            global_video[encChn]->active = true;
+            global_video[encChn]->is_activated.release();
+
+            LOG_DDEBUG("VIDEO UNLOCK" << 
+                       " channel:" << encChn);           
         }
     }
 
@@ -434,13 +474,17 @@ void *Worker::audio_grabber(void *arg)
     // inform main that initialization is complete
     sh->has_started.release();
 
+    /* 'active' indicates, the thread is activly polling and grabbing images
+     * 'running' describes the runlevel of the thread, if this value is set to false
+     *           the thread exits and cleanup all ressources 
+     */
+    global_video[encChn]->active = true;
     global_audio[encChn]->running = true;
     while (global_audio[encChn]->running)
     {
 
         if (global_audio[encChn]->hasDataCallback && cfg->audio.input_enabled)
         {
-
             if (IMP_AI_PollingFrame(global_audio[encChn]->devId, global_audio[encChn]->aiChn, cfg->general.imp_polling_timeout) == 0)
             {
                 IMPAudioFrame frame;
@@ -488,9 +532,12 @@ void *Worker::audio_grabber(void *arg)
         }
         else
         {
+            global_audio[encChn]->active = false;
             std::unique_lock<std::mutex> lock_stream{mutex_main};
             while (global_audio[encChn]->onDataCallback == nullptr && !global_restart_audio)
                 global_audio[encChn]->should_grab_frames.wait(lock_stream);
+
+            global_audio[encChn]->active = true;
         }
     } // while (global_audio[encChn]->running)
 
@@ -515,7 +562,7 @@ void *Worker::update_osd(void *arg)
         {
             if (v != nullptr)
             {
-                if (v->running)
+                if (v->active)
                 {
                     if ((v->imp_encoder->osd != nullptr))
                     {
@@ -538,7 +585,7 @@ void *Worker::update_osd(void *arg)
                 }
             }
         }
-        usleep(THREAD_SLEEP);
+        usleep(10000);
     }
 
     LOG_DEBUG("exit osd update thread.");


### PR DESCRIPTION
*fixed a bug in reading multiple osd values 
*fixed a bug in read and write motion roi
*fixed a bug receiving large json data
*fixed a bug in separator handling (,) in JSON response

Websocket rework:
The websocket implementation is now session capable. 
Incomming messages are now stored in the session specific structure 'u_ctx' in the member 'rx_message'.
Outgoing messages are now stored in the session specific structure 'u_ctx' in the member 'tx_message'.

When the preview image is requested via websocket, no current image is now requested from the encoder, it is always read and sent from /tmp/snapshot.jpg.
If the snapshot is requested faster than the encoder generates images, the delivery of the images is delayed on the server side.

Information on fps (frames per second) and Bps (bytes per second) can now be queried with json via websocket. 
{"stream(0|1|2)":{"stats":null}}
Inactive streams will return 0 values

The jpeg channel option 'jpeg_channel' which determines which encoder channel is used for the JPEG stream can now be configured with JSON via websocket.
{"stream2":{"jpeg_channel":null}}

The general options 'imp_polling_timeout' and 'osd_pool_size' also now available via json over websocket / http.
{"general":{"imp_polling_timeout":null, "osd_pool_size":null}}

WS now has set security required by default.
HTTP now has set security required by default.

'websocket.usertoken' option in prudynt.cfg now can be used to set a user specific token to acces websocket or http ressources.
This token must been added to the URL as a parameter.
new WebSocket('ws://<camera>:<port>?token=<usertoken>')
http://<camera>:<port>/preview.jpg?token=<usertoken>
sample: http://myThinginoCam:8089/preview.jpg?token=bigSecret


JPEG rework:
the JPEG thread continuously writes a current image to “/tmp/snapshot.jpg” when activated. 
If the image is requested via websocket or http, this file is always read and sent.

In preparation for an additional JPEG channel, the global variable 'gloabl_jpeg' is now an array.

If no preview images are requested via websocket or http, the jpeg thread goes into standby.
The channel is reactivated when new requests are received. 
The associated video stream is then also activated if it is not active.
Since the first encoder images after the start may be too dark, incomplete or without OSD, 
the first image is delivered with a delay after the thread is woken up. By default this is 100 milliseconds. 

Video rework:
The power saving option has been removed as the JPEG channel now activates the required video channel when needed. 
This means that the video channel can now always be suspended when no client is connected.

Config rework:
JPEG stream(2) 'format' option is removed from .cfg.
JPEG stream(2) 'height', 'width' option is removed from .cfg.