### PR TITLE
add AAC audio format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ CFLAGS += -DKERNEL_VERSION_4
 endif
 
 ifneq (,$(findstring -static,$(LDFLAGS)))
-LIBS = -limp -lalog -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lopus
+LIBS = -limp -lalog -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lopus -lfaac
 else
-LIBS = -limp -lalog -laudioProcess -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lopus
+LIBS = -limp -lalog -laudioProcess -lsysutils -lmuslshim -lliveMedia -lgroupsock -lBasicUsageEnvironment -lUsageEnvironment -lconfig++ -lwebsockets -lschrift -lopus -lfaac
 endif
 
 ifneq (,$(findstring -DPLATFORM_T31,$(CFLAGS)))

--- a/build.sh
+++ b/build.sh
@@ -155,6 +155,22 @@ deps() {
 	cp libmuslshim.* ../install/lib/
 	fi
 	cd $TOP
+
+	echo "Build faac"
+	cd 3rdparty
+	rm -rf faac
+	git clone --depth=1 https://github.com/knik0/faac.git
+	cd faac
+	sed -i 's/^#define MAX_CHANNELS 64/#define MAX_CHANNELS 1/' libfaac/coder.h
+	./bootstrap
+	if [[ "$2" == "-static" ]]; then
+		CC="${PRUDYNT_CROSS}gcc" ./configure --host mipsel-linux-gnu --prefix="$TOP/3rdparty/install" --enable-static --disable-shared
+	else
+		CC="${PRUDYNT_CROSS}gcc" ./configure --host mipsel-linux-gnu --prefix="$TOP/3rdparty/install" --disable-static --enable-shared
+	fi
+	make -j$(nproc)
+	make install
+	cd ../../
 }
 
 if [ $# -eq 0 ]; then

--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -208,7 +208,7 @@ websocket: {
 # --------------
 audio: {
 	# input_enabled: false;  # Enable or disable audio input.
-	# input_format: "OPUS";  # Audio format to use ("OPUS", "PCM", "G711A", "G711U", "G726").
+	# input_format: "OPUS";  # Audio format to use ("OPUS", "AAC", "PCM", "G711A", "G711U", "G726").
 	# input_bitrate: 40;  # Audio encoder bitrate to use in kbps (from 6 to 256).
 	# input_high_pass_filter: false;  # Enable or disable high pass filter for audio input.
 	# input_agc_enabled: false;  # Enable or disable AGC for audio input.

--- a/src/AACEncoder.cpp
+++ b/src/AACEncoder.cpp
@@ -1,0 +1,99 @@
+#include "AACEncoder.hpp"
+#include "Config.hpp"
+#include <cstdint>
+#include "Logger.hpp"
+
+AACEncoder* AACEncoder::createNew(int sampleRate, int numChn)
+{
+    return new AACEncoder(sampleRate, numChn);
+}
+
+AACEncoder::AACEncoder(int sampleRate, int numChn) : sampleRate(sampleRate), numChn(numChn)
+{
+}
+
+AACEncoder::~AACEncoder()
+{
+    close();
+}
+
+int AACEncoder::open()
+{
+    unsigned long outputBufferSize;
+    handle = faacEncOpen(sampleRate, numChn, &inputSamples, &outputBufferSize);
+    if (!handle)
+    {
+        LOG_ERROR("Failed to open FAAC encoder");
+        return -1;
+    }
+
+    faacEncConfigurationPtr config = faacEncGetCurrentConfiguration(handle);
+    config->aacObjectType = LOW;
+    config->bandWidth = sampleRate;
+    config->bitRate = cfg->audio.input_bitrate * 1000;
+    config->inputFormat = FAAC_INPUT_16BIT;
+    config->mpegVersion = MPEG4;
+    config->outputFormat = RAW_STREAM; // no need for ADTS headers
+
+    // Disable to reduce CPU utilization
+    config->allowMidside = 0;
+    config->useTns = 0;
+
+    if (!faacEncSetConfiguration(handle, config))
+    {
+        LOG_ERROR("Failed to configure FAAC encoder");
+        return -1;
+    }
+
+    LOG_INFO("faac expects " << inputSamples << " samples per frame");
+
+    return 0;
+}
+
+int AACEncoder::close()
+{
+    if (handle)
+    {
+        faacEncClose(handle);
+    }
+    handle = nullptr;
+    return 0;
+}
+
+int AACEncoder::encode(IMPAudioFrame *data, unsigned char *outbuf, int *outLen)
+{
+    if (!handle)
+    {
+        LOG_ERROR("FAAC encoder not available");
+        return -1;
+    }
+
+    const int frameSamples = data->len / sizeof(int16_t);
+    const int frameLen = faacEncEncode(
+        handle,
+        reinterpret_cast<int32_t*>(data->virAddr),
+        frameSamples,
+        reinterpret_cast<unsigned char*>(outbuf),
+        1024);
+    if (frameLen < 0)
+    {
+        LOG_WARN("Encoding failed with error code: " << frameLen);
+        return -1;
+    }
+
+    *outLen = frameLen;
+
+    if (frameSamples < inputSamples)
+    {
+        // Adjust the timestamp of the sequence because faac outputs 1024
+        // samples per frame and we only can provide 960 per frame (at 16 kHz).
+        const int64_t frameDurationIn = static_cast<int64_t>(frameSamples * 1000) / sampleRate;
+        const int64_t frameDurationOut = static_cast<int16_t>(inputSamples * 1000) / sampleRate;
+        const int64_t driftMs = frameDurationOut - frameDurationIn;
+        const int64_t frameNum = data->seq + 3; // faac buffers the first 3 frames
+        const int64_t timestampAdjustment = driftMs * frameNum;
+        data->timeStamp += timestampAdjustment;
+    }
+
+    return 0;
+}

--- a/src/AACEncoder.hpp
+++ b/src/AACEncoder.hpp
@@ -1,0 +1,26 @@
+#ifndef AAC_ENCODER_HPP
+#define AAC_ENCODER_HPP
+
+#include "IMPAudio.hpp"
+#include <faac.h>
+
+class AACEncoder : public IMPAudioEncoder
+{
+public:
+    static AACEncoder* createNew(int sampleRate, int numChn);
+
+    AACEncoder(int sampleRate, int numChn);
+    virtual ~AACEncoder();
+
+    int open() override;
+    int encode(IMPAudioFrame *data, unsigned char *outbuf, int *outLen) override;
+    int close() override;
+
+private:
+    unsigned long inputSamples;
+    faacEncHandle handle = nullptr;
+    int sampleRate;
+    int numChn;
+};
+
+#endif // AAC_ENCODER_HPP

--- a/src/AACSink.cpp
+++ b/src/AACSink.cpp
@@ -1,0 +1,51 @@
+#include "AACSink.hpp"
+#include <iomanip>
+#include <sstream>
+
+static uint8_t identifySamplingFrequencyIndex(unsigned samplingFrequency)
+{
+    // https://wiki.multimedia.cx/index.php/MPEG-4_Audio#Sampling_Frequencies
+    static constexpr size_t numFrequencies = 13;
+    static constexpr unsigned frequencies[numFrequencies] = {96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350};
+
+    for (unsigned i = 0; i < numFrequencies; ++i) {
+        if (frequencies[i] == samplingFrequency) {
+            return i;
+        }
+    }
+
+    return 15; // Reserved if not found
+}
+
+static std::string generateConfig(unsigned samplingFrequency, unsigned numChannels)
+{
+    // See RFC 3640
+    unsigned samplingFrequencyIndex = identifySamplingFrequencyIndex(samplingFrequency);
+    constexpr uint8_t objectType = 2; // AAC-LC
+    uint8_t channelConfiguration = static_cast<uint8_t>(numChannels);
+
+    uint16_t combined = (objectType << 11) | (samplingFrequencyIndex << 7) | (channelConfiguration << 3);
+
+    std::ostringstream configStream;
+    configStream << std::hex << std::setw(4) << std::setfill('0') << combined;
+    return configStream.str();
+}
+
+AACSink* AACSink::createNew(UsageEnvironment& env, Groupsock* RTPgs,
+                            u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
+                            unsigned samplingFrequency, unsigned numChannels)
+{
+    return new AACSink(env, RTPgs, rtpPayloadFormat, rtpTimestampFrequency, samplingFrequency, numChannels);
+}
+
+AACSink::AACSink(UsageEnvironment& env, Groupsock* RTPgs,
+                 u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
+                 unsigned samplingFrequency, unsigned numChannels)
+    : MPEG4GenericRTPSink(env, RTPgs, rtpPayloadFormat, rtpTimestampFrequency, "audio", "AAC-hbr",
+                          generateConfig(rtpTimestampFrequency, numChannels).c_str(), numChannels)
+{
+}
+
+AACSink::~AACSink()
+{
+}

--- a/src/AACSink.hpp
+++ b/src/AACSink.hpp
@@ -1,0 +1,19 @@
+#ifndef AAC_SINK_HPP
+#define AAC_SINK_HPP
+
+#include <liveMedia.hh>
+
+class AACSink : public MPEG4GenericRTPSink {
+public:
+    static AACSink* createNew(UsageEnvironment& env, Groupsock* RTPgs,
+                              u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
+                              unsigned samplingFrequency, unsigned numChannels);
+
+protected:
+    AACSink(UsageEnvironment& env, Groupsock* RTPgs,
+            u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
+            unsigned samplingFrequency, unsigned numChannels);
+    virtual ~AACSink();
+};
+
+#endif // AAC_SINK_HPP

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -129,7 +129,7 @@ std::vector<ConfigItem<const char *>> CFG::getCharItems()
     return {
 #if defined(AUDIO_SUPPORT)
         {"audio.input_format", audio.input_format, "OPUS", [](const char *v) {
-            std::set<std::string> a = {"OPUS", "PCM", "G711A", "G711U", "G726"};
+            std::set<std::string> a = {"OPUS", "AAC", "PCM", "G711A", "G711U", "G726"};
             return a.count(std::string(v)) == 1;
         }},
 #endif

--- a/src/IMPAudio.hpp
+++ b/src/IMPAudio.hpp
@@ -12,6 +12,7 @@ enum IMPAudioFormat
     G711U,
     G726,
     OPUS,
+    AAC,
 };
 
 class IMPAudioEncoder

--- a/src/IMPAudioServerMediaSubsession.cpp
+++ b/src/IMPAudioServerMediaSubsession.cpp
@@ -1,3 +1,4 @@
+#include "AACSink.hpp"
 #include "globals.hpp"
 #include "GroupsockHelper.hh"
 #include "liveMedia.hh"
@@ -71,6 +72,11 @@ RTPSink* IMPAudioServerMediaSubsession::createNewRTPSink(
         rtpPayloadFormatName = "OPUS";
         allowMultipleFramesPerPacket = false;
         break;
+    case IMPAudioFormat::AAC:
+        return AACSink::createNew(
+            envir(), rtpGroupsock, rtpPayloadFormat, rtpTimestampFrequency,
+            rtpTimestampFrequency,
+            /* numChannels */ 1);
     }
 
     return SimpleRTPSink::createNew(


### PR DESCRIPTION
This allows us to stream AAC over RTSP and support NVRs that don't support OPUS.

Unfortunately, `faac` requires 1024 samples per frame and IMP cannot provide us with that many audio samples. As such, we request 960 samples per frame and try to make ends meet. There is some slight audio crackling as part of this, but it's acceptable if the user must use AAC.

I have another branch that uses the `fdk-aac` library but it's too large (~3MB static to 11MB shared). I can share that as well if anyone is interested.

Evolution of https://github.com/gtxaspec/prudynt-t/pull/19