### PR TITLE
add AAC reframer

### DIFF
--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -210,6 +210,7 @@ audio: {
 	# input_enabled: false;  # Enable or disable audio input.
 	# input_format: "OPUS";  # Audio format to use ("OPUS", "AAC", "PCM", "G711A", "G711U", "G726").
 	# input_bitrate: 40;  # Audio encoder bitrate to use in kbps (from 6 to 256).
+	# input_sample_rate: 48000;  # Input audio sampling in Hz (8000, 16000, 24000, 44100, 48000).
 	# input_high_pass_filter: false;  # Enable or disable high pass filter for audio input.
 	# input_agc_enabled: false;  # Enable or disable AGC for audio input.
 	# input_vol: 80;  # Input volume for audio (-30 to 120).

--- a/src/AudioReframer.cpp
+++ b/src/AudioReframer.cpp
@@ -1,0 +1,73 @@
+#include "AudioReframer.hpp"
+#include <stdexcept>
+
+AudioReframer::AudioReframer(unsigned int inputSampleRate, unsigned int inputSamplesPerFrame, unsigned int outputSamplesPerFrame)
+    : inputSampleRate(inputSampleRate),
+      inputSamplesPerFrame(inputSamplesPerFrame),
+      outputSamplesPerFrame(outputSamplesPerFrame),
+      currentTimestamp(0),
+      samplesAccumulated(0)
+{
+    if (inputSamplesPerFrame == 0 || outputSamplesPerFrame == 0)
+    {
+        throw std::invalid_argument("Number of samples per frame must be greater than zero.");
+    }
+}
+
+void AudioReframer::addFrame(const std::vector<int16_t>& frameData, int64_t timestamp)
+{
+    if (frameData.size() != inputSamplesPerFrame)
+    {
+        throw std::invalid_argument("Frame data size must match input samples per frame.");
+    }
+
+    if (frameQueue.empty())
+    {
+        currentTimestamp = timestamp; // Initialize timestamp with the first frame
+    }
+
+    frameQueue.emplace_back(frameData);
+    samplesAccumulated += frameData.size();
+}
+
+void AudioReframer::getReframedFrame(std::vector<int16_t>& outputFrame, int64_t& outputTimestamp)
+{
+    if (!hasMoreFrames())
+    {
+        throw std::runtime_error("Insufficient samples to generate a reframed output.");
+    }
+
+    outputFrame.clear();
+    outputFrame.reserve(outputSamplesPerFrame);
+
+    size_t totalSamples = 0;
+    while (totalSamples < outputSamplesPerFrame && !frameQueue.empty())
+    {
+        auto& frameData = frameQueue.front();
+        size_t remainingSamples = outputSamplesPerFrame - totalSamples;
+        size_t samplesToCopy = std::min(remainingSamples, frameData.size());
+        outputFrame.insert(outputFrame.end(), frameData.begin(), frameData.begin() + samplesToCopy);
+        totalSamples += samplesToCopy;
+
+        // Remove the samples we used from the current frame
+        frameData.erase(frameData.begin(), frameData.begin() + samplesToCopy);
+
+        // If the current frame is fully consumed, remove it from the queue
+        if (frameData.empty())
+        {
+            frameQueue.pop_front();
+        }
+    }
+
+    // Set the output timestamp based on the first sample used for the output frame
+    outputTimestamp = currentTimestamp;
+
+    // Update the timestamp for the next frame to be retrieved
+    currentTimestamp += (outputSamplesPerFrame * 1000) / inputSampleRate;
+    samplesAccumulated -= outputSamplesPerFrame;
+}
+
+bool AudioReframer::hasMoreFrames() const
+{
+    return samplesAccumulated >= outputSamplesPerFrame;
+}

--- a/src/AudioReframer.hpp
+++ b/src/AudioReframer.hpp
@@ -1,0 +1,30 @@
+#ifndef AUDIO_REFRAMER_HPP
+#define AUDIO_REFRAMER_HPP
+
+#include <vector>
+#include <deque>
+#include <cstdint>
+
+class AudioReframer
+{
+public:
+    AudioReframer(unsigned int inputSampleRate, unsigned int inputSamplesPerFrame, unsigned int outputSamplesPerFrame);
+
+    void addFrame(const std::vector<int16_t>& frameData, int64_t timestamp);
+
+    void getReframedFrame(std::vector<int16_t>& outputFrame, int64_t& outputTimestamp);
+
+    bool hasMoreFrames() const;
+
+private:
+    unsigned int inputSampleRate;
+    unsigned int inputSamplesPerFrame;
+    unsigned int outputSamplesPerFrame;
+    int64_t currentTimestamp;
+    size_t samplesAccumulated;
+
+    using Frame = std::vector<int16_t>;
+    std::deque<Frame> frameQueue;
+};
+
+#endif // AUDIO_REFRAMER_HPP

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -177,6 +177,10 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
     return {
 #if defined(AUDIO_SUPPORT)
         {"audio.input_bitrate", audio.input_bitrate, 40, [](const int &v) { return v >= 6 && v <= 256; }},
+        {"audio.input_sample_rate", audio.input_sample_rate, 48000, [](const int &v) {
+            std::set<int> a = {8000, 16000, 24000, 44100, 48000};
+            return a.count(v) == 1;
+        }},
         {"audio.input_vol", audio.input_vol, 80, [](const int &v) { return v >= -30 && v <= 120; }},
         {"audio.input_gain", audio.input_gain, 25, [](const int &v) { return v >= 0 && v <= 31; }},
 #if defined(LIB_AUDIO_PROCESSING)

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -142,6 +142,7 @@ struct _audio {
     int input_vol;
     int input_bitrate;
     int input_gain;
+    int input_sample_rate;
 #if defined(LIB_AUDIO_PROCESSING)
     int input_alc_gain;  
     int input_noise_suppression;            

--- a/src/IMPAudio.cpp
+++ b/src/IMPAudio.cpp
@@ -62,9 +62,6 @@ int IMPAudio::init()
     else if (strcmp(cfg->audio.input_format, "AAC") == 0)
     {
         format = IMPAudioFormat::AAC;
-        encattr.bufSize = 20;
-        ioattr.samplerate = AUDIO_SAMPLE_RATE_16000;
-        frameDuration = 0.060; // IMP cannot do 0.066 or 1024 samples per frame
         bitrate = cfg->audio.input_bitrate;
         encoder = AACEncoder::createNew(ioattr.samplerate, ioattr.chnCnt);
     }

--- a/src/IMPAudio.hpp
+++ b/src/IMPAudio.hpp
@@ -41,6 +41,7 @@ public:
     int init();
     int deinit();
     int bitrate;    // computed during setup, in Kbps
+    int sample_rate;
     IMPAudioFormat format;
 
     int inChn{};

--- a/src/IMPAudioServerMediaSubsession.cpp
+++ b/src/IMPAudioServerMediaSubsession.cpp
@@ -45,7 +45,7 @@ RTPSink* IMPAudioServerMediaSubsession::createNewRTPSink(
     FramedSource* inputSource)
 {
     unsigned rtpPayloadFormat = rtpPayloadTypeIfDynamic;
-    unsigned rtpTimestampFrequency = 16000;
+    unsigned rtpTimestampFrequency = global_audio[audioChn]->imp_audio->sample_rate;
     const char *rtpPayloadFormatName;
     bool allowMultipleFramesPerPacket = true;
     switch (global_audio[audioChn]->imp_audio->format)
@@ -55,16 +55,13 @@ RTPSink* IMPAudioServerMediaSubsession::createNewRTPSink(
         break;
     case IMPAudioFormat::G711A:
         rtpPayloadFormat = 8;
-        rtpTimestampFrequency = 8000;
         rtpPayloadFormatName = "PCMA";
         break;
     case IMPAudioFormat::G711U:
         rtpPayloadFormat = 0;
-        rtpTimestampFrequency = 8000;
         rtpPayloadFormatName = "PCMU";
         break;
     case IMPAudioFormat::G726:
-        rtpTimestampFrequency = 8000;
         rtpPayloadFormatName = "G726-16";
         break;
     case IMPAudioFormat::OPUS:

--- a/src/WS.cpp
+++ b/src/WS.cpp
@@ -201,7 +201,8 @@ enum
     PNT_AUDIO_INPUT_AGC_TARGET_LEVEL_DBFS,
     PNT_AUDIO_INPUT_AGC_COMPRESSION_GAIN_DB,
     PNT_AUDIO_INPUT_BITRATE,
-    PNT_AUDIO_INPUT_FORMAT
+    PNT_AUDIO_INPUT_FORMAT,
+    PNT_AUDIO_INPUT_SAMPLE_RATE
 };
 
 static const char *const audio_keys[] = {
@@ -214,8 +215,9 @@ static const char *const audio_keys[] = {
     "input_noise_suppression",
     "input_agc_target_level_dbfs",
     "input_agc_compression_gain_db",
-    "input_bitrate"
-    "input_format"};
+    "input_bitrate",
+    "input_format",
+    "input_sample_rate"};
 #endif
 
 /* STREAM */


### PR DESCRIPTION
This reframes the PCM input to the AAC encoder to be the expected 1024 samples. It also allows you to set the sample rate in the configuration (technically the devices support 96 kHz but it's absurd to even consider so I left it off.)