### PR TITLE
new feature jpeg_idle_fps

### DIFF
--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -193,6 +193,7 @@ stream2: {
 	# jpeg_quality: 75;  # Quality of JPEG snapshots (1-100).
 	# jpeg_refresh: 1000;  # Refresh rate for JPEG snapshots (in milliseconds).
 	# jpeg_channel: 0;  # JPEG channel (0 or 1).
+	# jpeg_idle_fps: 1; # fps if no requests made via ws / http. 0 = sleep on idle. ! affects jpeg_path
 };
 
 # WebSocket Settings

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -304,6 +304,7 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
         {"stream1.profile", stream1.profile, 2, validateInt2},
         {"stream2.jpeg_channel", stream2.jpeg_channel, 0, validateIntGe0},
         {"stream2.jpeg_quality", stream2.jpeg_quality, 75, [](const int &v) { return v > 0 && v <= 100; }},
+        {"stream2.jpeg_idle_fps", stream2.jpeg_idle_fps, 1, [](const int &v) { return v >= 0 && v <= 30; }},
         {"stream2.fps", stream2.fps, 25, [](const int &v) { return v > 1 && v <= 30; }},
         {"websocket.loglevel", websocket.loglevel, 4096, [](const int &v) { return v > 0 && v <= 1024; }},
         {"websocket.port", websocket.port, 8089, validateInt65535},

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -230,6 +230,7 @@ struct _stream {
     int jpeg_quality;
     int jpeg_refresh;
     int jpeg_channel;
+    int jpeg_idle_fps;
     const char *jpeg_path;
     _osd osd;
     _stream_stats stats;

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -13,6 +13,10 @@
 #define NUM_AUDIO_CHANNELS 1
 #define NUM_VIDEO_CHANNELS 2
 
+using namespace std::chrono;
+
+extern std::mutex mutex_main; // protects global_restart_rtsp and global_restart_video
+
 struct AudioFrame
 {
 	std::vector<uint8_t> data;
@@ -26,22 +30,37 @@ struct H264NALUnit
 	int64_t imp_ts;
 };
 
-struct jpeg_stream {
+struct jpeg_stream
+{
     int encChn;
-    _stream* stream;
-    int subscribers{0};
-    std::atomic<bool> running;   // set to false to make jpeg_grabber thread exit
+    _stream *stream;
+    std::atomic<bool> running; // set to false to make jpeg_grabber thread exit
     std::atomic<bool> active{false};
     pthread_t thread;
-    IMPEncoder * imp_encoder;   
+    IMPEncoder *imp_encoder;
     std::condition_variable should_grab_frames;
     std::binary_semaphore is_activated{0};
 
-    jpeg_stream(int encChn, _stream* stream)
-        : encChn(encChn), stream(stream), running(false), imp_encoder(nullptr) {}  
+    steady_clock::time_point last_image;
+    steady_clock::time_point last_subscriber;
+
+    void request()
+    {
+        auto now = steady_clock::now();
+        std::unique_lock lck(mutex_main);
+        last_subscriber = now;
+    }
+
+    bool request_or_overrun() {
+        return duration_cast<milliseconds>(steady_clock::now() - last_subscriber).count() < 1000;
+    }
+
+    jpeg_stream(int encChn, _stream *stream)
+        : encChn(encChn), stream(stream), running(false), imp_encoder(nullptr) {}
 };
 
-struct audio_stream {
+struct audio_stream
+{
     int devId;
     int aiChn;
     int aeChn;
@@ -57,7 +76,7 @@ struct audio_stream {
      * is registered right now.
      */
     std::atomic<bool> hasDataCallback;
-    std::mutex onDataCallbackLock;    // protects onDataCallback from deallocation
+    std::mutex onDataCallbackLock; // protects onDataCallback from deallocation
     std::condition_variable should_grab_frames;
     std::binary_semaphore is_activated{0};
 
@@ -67,9 +86,10 @@ struct audio_stream {
           onDataCallback{nullptr}, hasDataCallback{false} {}
 };
 
-struct video_stream {
+struct video_stream
+{
     int encChn;
-    _stream* stream;
+    _stream *stream;
     const char *name;
     bool running;
     pthread_t thread;
@@ -80,29 +100,28 @@ struct video_stream {
     IMPFramesource *imp_framesource;
     std::shared_ptr<MsgChannel<H264NALUnit>> msgChannel;
     std::function<void(void)> onDataCallback;
-    bool run_for_jpeg;                      // see comment in audio_stream
-    std::atomic<bool> hasDataCallback;      // see comment in audio_stream
-    std::mutex onDataCallbackLock;          // protects onDataCallback from deallocation
+    bool run_for_jpeg;                 // see comment in audio_stream
+    std::atomic<bool> hasDataCallback; // see comment in audio_stream
+    std::mutex onDataCallbackLock;     // protects onDataCallback from deallocation
     std::condition_variable should_grab_frames;
     std::binary_semaphore is_activated{0};
 
-    video_stream(int encChn, _stream* stream, const char *name)
+    video_stream(int encChn, _stream *stream, const char *name)
         : encChn(encChn), stream(stream), running(false), name(name), idr(false), imp_encoder(nullptr), imp_framesource(nullptr),
-          msgChannel(std::make_shared<MsgChannel<H264NALUnit>>(MSG_CHANNEL_SIZE)), onDataCallback(nullptr), idr_fix(0), run_for_jpeg{false}, 
+          msgChannel(std::make_shared<MsgChannel<H264NALUnit>>(MSG_CHANNEL_SIZE)), onDataCallback(nullptr), idr_fix(0), run_for_jpeg{false},
           hasDataCallback{false} {}
 };
 
 extern std::condition_variable global_cv_worker_restart;
 
-extern std::mutex mutex_main;   // protects global_restart_rtsp and global_restart_video
 extern bool global_restart_rtsp;
 extern bool global_restart_video;
 extern bool global_restart_audio;
 
-extern bool global_osd_thread_signal; 
+extern bool global_osd_thread_signal;
 extern bool global_main_thread_signal;
-extern bool global_motion_thread_signal; 
-extern char volatile global_rtsp_thread_signal; 
+extern bool global_motion_thread_signal;
+extern char volatile global_rtsp_thread_signal;
 
 extern std::shared_ptr<jpeg_stream> global_jpeg[NUM_VIDEO_CHANNELS];
 extern std::shared_ptr<audio_stream> global_audio[NUM_AUDIO_CHANNELS];

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -124,9 +124,9 @@ void *Worker::jpeg_grabber(void *arg)
         {
             auto diff_last_image = duration_cast<milliseconds>(now - global_jpeg[jpgChn]->last_image).count();
 
-            // we remove 2 millisecond's as image creation time
+            // we remove targetFps/10 millisecond's as image creation time
             // by this we get besser FPS results
-            if(targetFps && diff_last_image >= ((1000/targetFps)-2))
+            if(targetFps && diff_last_image >= ((1000/targetFps)-targetFps/10))
             {   
                 // check if current jpeg channal is running if not start it
                 if(!global_video[global_jpeg[jpgChn]->stream->jpeg_channel]->active) {


### PR DESCRIPTION
the last image request via ws/http determines the frame rate. With a request, an attempt is made to deliver the framerate stream.fps, after which an attempt is made to serve the framerate stream.jpeg_idle_fps. If jpeg_idle_fps = 0 then the jpeg worker thread is put to sleep. It is woken up again with the next request.