### PR TITLE
fix AAC crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CXX = ${CROSS_COMPILE}g++
 
 DEBUG=n
 
-CXXFLAGS = $(CFLAGS) -std=c++20
+CXXFLAGS = $(CFLAGS) -std=c++20 -Wall -Wextra -Wno-unused-parameter
 LDFLAGS = -lrt
 
 CFLAGS = -Wall -Wextra -Wno-unused-parameter -O2 -DNO_OPENSSL=1

--- a/src/AACEncoder.cpp
+++ b/src/AACEncoder.cpp
@@ -68,7 +68,7 @@ int AACEncoder::encode(IMPAudioFrame *data, unsigned char *outbuf, int *outLen)
         return -1;
     }
 
-    const int frameSamples = data->len / sizeof(int16_t);
+    const auto frameSamples = data->len / sizeof(int16_t);
     if (frameSamples != inputSamples)
     {
         LOG_WARN("FAAC was provided with " << frameSamples << " samples per frame.");

--- a/src/AACSink.cpp
+++ b/src/AACSink.cpp
@@ -33,14 +33,14 @@ static std::string generateConfig(unsigned samplingFrequency, unsigned numChanne
 
 AACSink* AACSink::createNew(UsageEnvironment& env, Groupsock* RTPgs,
                             u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
-                            unsigned samplingFrequency, unsigned numChannels)
+                            unsigned numChannels)
 {
-    return new AACSink(env, RTPgs, rtpPayloadFormat, rtpTimestampFrequency, samplingFrequency, numChannels);
+    return new AACSink(env, RTPgs, rtpPayloadFormat, rtpTimestampFrequency, numChannels);
 }
 
 AACSink::AACSink(UsageEnvironment& env, Groupsock* RTPgs,
                  u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
-                 unsigned samplingFrequency, unsigned numChannels)
+                 unsigned numChannels)
     : MPEG4GenericRTPSink(env, RTPgs, rtpPayloadFormat, rtpTimestampFrequency, "audio", "AAC-hbr",
                           config = strdup(generateConfig(rtpTimestampFrequency, numChannels).c_str()),
                           numChannels)

--- a/src/AACSink.cpp
+++ b/src/AACSink.cpp
@@ -42,10 +42,12 @@ AACSink::AACSink(UsageEnvironment& env, Groupsock* RTPgs,
                  u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
                  unsigned samplingFrequency, unsigned numChannels)
     : MPEG4GenericRTPSink(env, RTPgs, rtpPayloadFormat, rtpTimestampFrequency, "audio", "AAC-hbr",
-                          generateConfig(rtpTimestampFrequency, numChannels).c_str(), numChannels)
+                          config = strdup(generateConfig(rtpTimestampFrequency, numChannels).c_str()),
+                          numChannels)
 {
 }
 
 AACSink::~AACSink()
 {
+    free(config);
 }

--- a/src/AACSink.hpp
+++ b/src/AACSink.hpp
@@ -14,6 +14,9 @@ protected:
             u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
             unsigned samplingFrequency, unsigned numChannels);
     virtual ~AACSink();
+
+private:
+    char* config;
 };
 
 #endif // AAC_SINK_HPP

--- a/src/AACSink.hpp
+++ b/src/AACSink.hpp
@@ -7,12 +7,12 @@ class AACSink : public MPEG4GenericRTPSink {
 public:
     static AACSink* createNew(UsageEnvironment& env, Groupsock* RTPgs,
                               u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
-                              unsigned samplingFrequency, unsigned numChannels);
+                              unsigned numChannels);
 
 protected:
     AACSink(UsageEnvironment& env, Groupsock* RTPgs,
             u_int8_t rtpPayloadFormat, u_int32_t rtpTimestampFrequency,
-            unsigned samplingFrequency, unsigned numChannels);
+            unsigned numChannels);
     virtual ~AACSink();
 
 private:

--- a/src/AudioReframer.cpp
+++ b/src/AudioReframer.cpp
@@ -1,4 +1,5 @@
 #include "AudioReframer.hpp"
+#include <algorithm>
 #include <stdexcept>
 
 AudioReframer::AudioReframer(unsigned int inputSampleRate, unsigned int inputSamplesPerFrame, unsigned int outputSamplesPerFrame)
@@ -6,7 +7,8 @@ AudioReframer::AudioReframer(unsigned int inputSampleRate, unsigned int inputSam
       inputSamplesPerFrame(inputSamplesPerFrame),
       outputSamplesPerFrame(outputSamplesPerFrame),
       currentTimestamp(0),
-      samplesAccumulated(0)
+      samplesAccumulated(0),
+      buffer(2 * std::max(inputSamplesPerFrame, outputSamplesPerFrame) * sizeof(uint16_t))
 {
     if (inputSamplesPerFrame == 0 || outputSamplesPerFrame == 0)
     {
@@ -14,60 +16,45 @@ AudioReframer::AudioReframer(unsigned int inputSampleRate, unsigned int inputSam
     }
 }
 
-void AudioReframer::addFrame(const std::vector<int16_t>& frameData, int64_t timestamp)
+void AudioReframer::addFrame(const uint8_t* frameData, int64_t timestamp)
 {
-    if (frameData.size() != inputSamplesPerFrame)
+    if (frameData == nullptr)
     {
-        throw std::invalid_argument("Frame data size must match input samples per frame.");
+        throw std::invalid_argument("Frame data cannot be null.");
     }
 
-    if (frameQueue.empty())
+    size_t inputFrameSize = inputSamplesPerFrame * sizeof(uint16_t);
+    buffer.push(frameData, inputFrameSize);
+
+    if (samplesAccumulated == 0)
     {
         currentTimestamp = timestamp; // Initialize timestamp with the first frame
     }
 
-    frameQueue.emplace_back(frameData);
-    samplesAccumulated += frameData.size();
+    samplesAccumulated += inputSamplesPerFrame;
 }
 
-void AudioReframer::getReframedFrame(std::vector<int16_t>& outputFrame, int64_t& outputTimestamp)
+void AudioReframer::getReframedFrame(uint8_t* frameData, int64_t& timestamp)
 {
     if (!hasMoreFrames())
     {
         throw std::runtime_error("Insufficient samples to generate a reframed output.");
     }
 
-    outputFrame.clear();
-    outputFrame.reserve(outputSamplesPerFrame);
-
-    size_t totalSamples = 0;
-    while (totalSamples < outputSamplesPerFrame && !frameQueue.empty())
-    {
-        auto& frameData = frameQueue.front();
-        size_t remainingSamples = outputSamplesPerFrame - totalSamples;
-        size_t samplesToCopy = std::min(remainingSamples, frameData.size());
-        outputFrame.insert(outputFrame.end(), frameData.begin(), frameData.begin() + samplesToCopy);
-        totalSamples += samplesToCopy;
-
-        // Remove the samples we used from the current frame
-        frameData.erase(frameData.begin(), frameData.begin() + samplesToCopy);
-
-        // If the current frame is fully consumed, remove it from the queue
-        if (frameData.empty())
-        {
-            frameQueue.pop_front();
-        }
+    if (frameData == nullptr) {
+        throw std::invalid_argument("Output frame cannot be null.");
     }
 
-    // Set the output timestamp based on the first sample used for the output frame
-    outputTimestamp = currentTimestamp;
-
-    // Update the timestamp for the next frame to be retrieved
-    currentTimestamp += (outputSamplesPerFrame * 1000) / inputSampleRate;
+    size_t outputFrameSize = outputSamplesPerFrame * sizeof(uint16_t);
+    buffer.fetch(frameData, outputFrameSize);
     samplesAccumulated -= outputSamplesPerFrame;
+
+    timestamp = currentTimestamp;
+    currentTimestamp += (outputSamplesPerFrame * 1000) / inputSampleRate;
 }
 
 bool AudioReframer::hasMoreFrames() const
 {
     return samplesAccumulated >= outputSamplesPerFrame;
 }
+

--- a/src/AudioReframer.hpp
+++ b/src/AudioReframer.hpp
@@ -1,18 +1,18 @@
 #ifndef AUDIO_REFRAMER_HPP
 #define AUDIO_REFRAMER_HPP
 
-#include <vector>
-#include <deque>
 #include <cstdint>
+#include <cstddef>
+#include "RingBuffer.hpp"
 
 class AudioReframer
 {
 public:
     AudioReframer(unsigned int inputSampleRate, unsigned int inputSamplesPerFrame, unsigned int outputSamplesPerFrame);
 
-    void addFrame(const std::vector<int16_t>& frameData, int64_t timestamp);
+    void addFrame(const uint8_t* frameData, int64_t timestamp);
 
-    void getReframedFrame(std::vector<int16_t>& outputFrame, int64_t& outputTimestamp);
+    void getReframedFrame(uint8_t* frameData, int64_t& timestamp);
 
     bool hasMoreFrames() const;
 
@@ -23,8 +23,8 @@ private:
     int64_t currentTimestamp;
     size_t samplesAccumulated;
 
-    using Frame = std::vector<int16_t>;
-    std::deque<Frame> frameQueue;
+    RingBuffer buffer;
 };
 
 #endif // AUDIO_REFRAMER_HPP
+

--- a/src/IMPAudio.cpp
+++ b/src/IMPAudio.cpp
@@ -46,7 +46,7 @@ int IMPAudio::init()
     };
     IMPAudioEncChnAttr encattr = {
         .type = IMPAudioPalyloadType::PT_PCM,
-        .bufSize = 2,
+        .bufSize = 20,
     };
     float frameDuration = 0.040;
 

--- a/src/IMPAudio.hpp
+++ b/src/IMPAudio.hpp
@@ -44,9 +44,9 @@ public:
     int sample_rate;
     IMPAudioFormat format;
 
+    int devId{};
     int inChn{};
     int aeChn{};
-    int devId{};
 
 private:
     int handle = 0;

--- a/src/IMPAudioServerMediaSubsession.cpp
+++ b/src/IMPAudioServerMediaSubsession.cpp
@@ -46,12 +46,11 @@ RTPSink* IMPAudioServerMediaSubsession::createNewRTPSink(
 {
     unsigned rtpPayloadFormat = rtpPayloadTypeIfDynamic;
     unsigned rtpTimestampFrequency = global_audio[audioChn]->imp_audio->sample_rate;
-    const char *rtpPayloadFormatName;
+    const char* rtpPayloadFormatName = "L16";
     bool allowMultipleFramesPerPacket = true;
     switch (global_audio[audioChn]->imp_audio->format)
     {
     case IMPAudioFormat::PCM:
-        rtpPayloadFormatName = "L16";
         break;
     case IMPAudioFormat::G711A:
         rtpPayloadFormat = 8;
@@ -72,7 +71,6 @@ RTPSink* IMPAudioServerMediaSubsession::createNewRTPSink(
     case IMPAudioFormat::AAC:
         return AACSink::createNew(
             envir(), rtpGroupsock, rtpPayloadFormat, rtpTimestampFrequency,
-            rtpTimestampFrequency,
             /* numChannels */ 1);
     }
 

--- a/src/RingBuffer.hpp
+++ b/src/RingBuffer.hpp
@@ -1,0 +1,75 @@
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+
+class RingBuffer
+{
+public:
+    RingBuffer(size_t capacity)
+        : buffer(new uint8_t[capacity]), capacity(capacity), head(0), tail(0), size(0)
+    {}
+
+    ~RingBuffer()
+    {
+        delete[] buffer;
+    }
+
+    void push(const uint8_t* data, size_t dataSize)
+    {
+        if (dataSize > capacity - size)
+        {
+            throw std::overflow_error("Ring buffer overflow");
+        }
+
+        size_t spaceAtEnd = capacity - tail;
+        if (dataSize <= spaceAtEnd)
+        {
+            // If we can fit the data without wrapping
+            std::memcpy(buffer + tail, data, dataSize);
+        }
+        else
+        {
+            // If the data wraps around the buffer
+            std::memcpy(buffer + tail, data, spaceAtEnd);
+            std::memcpy(buffer, data + spaceAtEnd, dataSize - spaceAtEnd);
+        }
+
+        tail = (tail + dataSize) % capacity;
+        size += dataSize;
+    }
+
+    void fetch(uint8_t* output, size_t count)
+    {
+        if (count > size)
+        {
+            throw std::underflow_error("Ring buffer underflow");
+        }
+
+        size_t spaceAtEnd = capacity - head;
+        if (count <= spaceAtEnd)
+        {
+            // If the data can be copied without wrapping
+            std::memcpy(output, buffer + head, count);
+        }
+        else
+        {
+            // If the data wraps around the buffer
+            std::memcpy(output, buffer + head, spaceAtEnd);
+            std::memcpy(output + spaceAtEnd, buffer, count - spaceAtEnd);
+        }
+
+        head = (head + count) % capacity;
+        size -= count;
+    }
+
+    bool isEmpty() const { return size == 0; }
+    size_t getSize() const { return size; }
+
+private:
+    uint8_t* buffer;
+    size_t capacity;
+    size_t head;
+    size_t tail;
+    size_t size;
+};


### PR DESCRIPTION
Fix a use-after-free bug, UB when the audio encoder exhausted its frame buffer, and improve memory efficiency with a ring buffer.