### PR TITLE
fix Opus SDP channels to be 2 as per RFC 7587

### DIFF
--- a/src/IMPAudioServerMediaSubsession.cpp
+++ b/src/IMPAudioServerMediaSubsession.cpp
@@ -80,6 +80,7 @@ RTPSink* IMPAudioServerMediaSubsession::createNewRTPSink(
         rtpTimestampFrequency = 48000;
         rtpPayloadFormatName = "OPUS";
         allowMultipleFramesPerPacket = false;
+        outChnCnt = 2;
         break;
     case IMPAudioFormat::AAC:
         return AACSink::createNew(


### PR DESCRIPTION
We must set the number of channels to 2 for Opus as per https://datatracker.ietf.org/doc/html/rfc7587

Found as part of https://github.com/AlexxIT/go2rtc/issues/1506