### PR TITLE
Two-Way Audio Support

### DIFF
--- a/prudynt.cfg.example
+++ b/prudynt.cfg.example
@@ -225,6 +225,8 @@ audio: {
 	# input_agc_compression_gain_db: 0;  # AGC compression gain in dB for audio input (0 to 90).
 	# input_noise_suppression: 0;  # Noise suppression for audio input (0 to 3).
 	# force_stereo: false; # Enable stereo audio, best supported under PCM and OPUS.  AAC may have errors.
+	# output_enabled: false; # Enable or disable two-way audio output, also known as backchannel audio.
+	# output_sample_rate: 16000; # Output audio sampling in Hz (8000, 16000, 24000, 44100, 48000).  Must match IAD.
 };
 
 # Motion Settings

--- a/src/BackchannelProcessor.cpp
+++ b/src/BackchannelProcessor.cpp
@@ -1,0 +1,420 @@
+#include "BackchannelProcessor.hpp"
+
+#include "Logger.hpp"
+#include "globals.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include <imp/imp_audio.h>
+
+#define MODULE "BackchannelProcessor"
+
+BackchannelProcessor::BackchannelProcessor()
+    : currentSessionId(0)
+    , fPipe(nullptr)
+    , fPipeFd(-1)
+{}
+
+BackchannelProcessor::~BackchannelProcessor()
+{
+    closePipe();
+}
+
+static int getFrequency(IMPBackchannelFormat format)
+{
+#define RETURN_FREQUENCY(EnumName, NameString, PayloadType, Frequency, MimeType) \
+    { \
+        if (IMPBackchannelFormat::EnumName == format) \
+            return Frequency; \
+    }
+    X_FOREACH_BACKCHANNEL_FORMAT(RETURN_FREQUENCY)
+#undef RETURN_FREQUENCY
+    return 8000;
+}
+
+static const char *getFormatName(IMPBackchannelFormat format)
+{
+#define RETURN_NAME(EnumName, NameString, PayloadType, Frequency, MimeType) \
+    { \
+        if (IMPBackchannelFormat::EnumName == format) \
+            return NameString; \
+    }
+    X_FOREACH_BACKCHANNEL_FORMAT(RETURN_NAME)
+#undef RETURN_NAME
+    return "UNKNOWN";
+}
+
+std::vector<int16_t> BackchannelProcessor::resampleLinear(const std::vector<int16_t> &input_pcm,
+                                                          int input_rate,
+                                                          int output_rate)
+{
+    assert(input_rate != output_rate);
+
+    double ratio = static_cast<double>(output_rate) / input_rate;
+    size_t output_size = static_cast<size_t>(
+        std::max(1.0, std::round(static_cast<double>(input_pcm.size()) * ratio)));
+
+    std::vector<int16_t> output_pcm(output_size);
+    size_t input_size = input_pcm.size();
+
+    for (size_t i = 0; i < output_size; ++i)
+    {
+        double input_pos = static_cast<double>(i) / ratio;
+        size_t index1 = static_cast<size_t>(input_pos);
+
+        if (index1 >= input_size)
+        {
+            index1 = input_size - 1;
+        }
+
+        int16_t sample1 = input_pcm[index1];
+        int16_t sample2 = (index1 + 1 < input_size) ? input_pcm[index1 + 1] : sample1;
+
+        double factor = input_pos - static_cast<double>(index1);
+
+        double interpolated_sample = static_cast<double>(sample1) * (1.0 - factor)
+                                     + static_cast<double>(sample2) * factor;
+
+        if (interpolated_sample > INT16_MAX)
+            interpolated_sample = INT16_MAX;
+        if (interpolated_sample < INT16_MIN)
+            interpolated_sample = INT16_MIN;
+
+        output_pcm[i] = static_cast<int16_t>(interpolated_sample);
+    }
+
+    return output_pcm;
+}
+
+bool BackchannelProcessor::initPipe()
+{
+    if (fPipe)
+    {
+        LOG_DEBUG("Pipe already initialized.");
+        return true;
+    }
+    LOG_DEBUG("Opening pipe to: /bin/iac -s");
+    fPipe = popen("/bin/iac -s", "w");
+    if (fPipe == nullptr)
+    {
+        LOG_ERROR("popen failed: " << strerror(errno));
+        fPipeFd = -1;
+        return false;
+    }
+
+    fPipeFd = fileno(fPipe);
+    if (fPipeFd == -1)
+    {
+        LOG_ERROR("fileno failed: " << strerror(errno));
+        closePipe();
+        return false;
+    }
+
+    int flags = fcntl(fPipeFd, F_GETFL, 0);
+    if (flags == -1)
+    {
+        LOG_ERROR("fcntl(F_GETFL) failed: " << strerror(errno));
+        closePipe();
+        return false;
+    }
+
+    if (fcntl(fPipeFd, F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        LOG_ERROR("fcntl(F_SETFL, O_NONBLOCK) failed: " << strerror(errno));
+        closePipe();
+        return false;
+    }
+
+    LOG_DEBUG("Pipe opened successfully (fd=" << fPipeFd << ").");
+    return true;
+}
+
+void BackchannelProcessor::closePipe()
+{
+    if (fPipe)
+    {
+        LOG_DEBUG("Closing pipe (fd=" << fPipeFd << ").");
+        int ret = pclose(fPipe);
+        fPipe = nullptr;
+        fPipeFd = -1;
+        if (ret == -1)
+        {
+            LOG_ERROR("pclose() failed: " << strerror(errno));
+        }
+        else
+        {
+            if (WIFEXITED(ret))
+            {
+                LOG_DEBUG("Pipe process exited with status: " << WEXITSTATUS(ret));
+            }
+            else if (WIFSIGNALED(ret))
+            {
+                LOG_WARN("Pipe process terminated by signal: " << WTERMSIG(ret));
+            }
+            else
+            {
+                LOG_WARN("Pipe process stopped for unknown reason.");
+            }
+        }
+    }
+}
+
+bool BackchannelProcessor::decodeFrame(const uint8_t *payload,
+                                       size_t payloadSize,
+                                       IMPBackchannelFormat format,
+                                       std::vector<int16_t> &outPcmBuffer)
+{
+    IMPAudioStream stream_in;
+    stream_in.stream = const_cast<uint8_t *>(payload);
+    stream_in.len = static_cast<int>(payloadSize);
+
+    int adChn = (int) format;
+    int ret = IMP_ADEC_SendStream(adChn, &stream_in, BLOCK);
+    if (ret != 0)
+    {
+        LOG_ERROR("IMP_ADEC_SendStream failed for channel " << adChn << ": " << ret);
+        return false;
+    }
+
+    IMPAudioStream stream_out;
+    ret = IMP_ADEC_GetStream(adChn, &stream_out, BLOCK);
+    if (ret == 0 && stream_out.len > 0 && stream_out.stream != nullptr)
+    {
+        size_t num_samples = stream_out.len / sizeof(int16_t);
+        if (stream_out.len % sizeof(int16_t) != 0)
+        {
+            LOG_WARN("Decoded stream length (" << stream_out.len
+                                               << ") not multiple of int16_t size. Truncating.");
+        }
+        outPcmBuffer.assign(reinterpret_cast<int16_t *>(stream_out.stream),
+                            reinterpret_cast<int16_t *>(stream_out.stream) + num_samples);
+        IMP_ADEC_ReleaseStream(adChn, &stream_out);
+        return true;
+    }
+    else if (ret != 0)
+    {
+        LOG_ERROR("IMP_ADEC_GetStream failed for channel " << adChn << ": " << ret);
+        return false;
+    }
+
+    LOG_DEBUG("ADEC_GetStream succeeded but produced no data.");
+    outPcmBuffer.clear();
+    return true;
+}
+
+bool BackchannelProcessor::writePcmToPipe(const std::vector<int16_t> &pcmBuffer)
+{
+    if (fPipeFd == -1 || fPipe == nullptr)
+    {
+        LOG_ERROR("Pipe is closed (fd=" << fPipeFd << "), cannot write PCM data.");
+        return false;
+    }
+    if (pcmBuffer.empty())
+    {
+        LOG_DEBUG("Attempted to write empty PCM buffer to pipe.");
+        return true;
+    }
+
+    size_t bytesToWrite = pcmBuffer.size() * sizeof(int16_t);
+    const uint8_t *dataPtr = reinterpret_cast<const uint8_t *>(pcmBuffer.data());
+
+    ssize_t bytesWritten = write(fPipeFd, dataPtr, bytesToWrite);
+
+    if (bytesWritten == static_cast<ssize_t>(bytesToWrite))
+    {
+        // Bytes written match expected size
+    }
+    else if (bytesWritten >= 0)
+    {
+        LOG_WARN("Partial write to pipe (" << bytesWritten << "/" << bytesToWrite
+                                           << "). Assuming pipe clogged.");
+        return true;
+    }
+    else
+    {
+        int saved_errno = errno;
+        if (saved_errno == EAGAIN || saved_errno == EWOULDBLOCK)
+        {
+            LOG_WARN("Pipe clogged (EAGAIN/EWOULDBLOCK). Discarding PCM chunk.");
+            return true;
+        }
+        else if (saved_errno == EPIPE)
+        {
+            LOG_ERROR("write() failed: Broken pipe (EPIPE). Assuming pipe closed by "
+                      "reader.");
+            closePipe();
+            return false;
+        }
+        else
+        {
+            LOG_ERROR("write() failed: errno=" << saved_errno << ": " << strerror(saved_errno)
+                                               << ". Assuming pipe closed.");
+            closePipe();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool BackchannelProcessor::processFrame(const BackchannelFrame &frame)
+{
+    if (!cfg->audio.output_enabled)
+    {
+        return true;
+    }
+
+    std::vector<int16_t> decoded_pcm;
+    if (!decodeFrame(frame.payload.data(), frame.payload.size(), frame.format, decoded_pcm))
+    {
+        // Error already logged in decodeFrame
+        return true; // Continue processing loop, maybe next frame works
+    }
+
+    if (decoded_pcm.empty())
+    {
+        LOG_WARN("decodeFrame returned empty PCM buffer.");
+        return true; // Nothing to process
+    }
+
+    // Resample only if necessary
+    int input_rate = getFrequency(frame.format);
+    int target_rate = cfg->audio.output_sample_rate;
+    const std::vector<int16_t> *buffer_to_write = &decoded_pcm;
+    std::vector<int16_t> resampled_pcm;
+
+    if (input_rate != target_rate)
+    {
+        resampled_pcm = resampleLinear(decoded_pcm, input_rate, target_rate);
+        buffer_to_write = &resampled_pcm;
+    }
+
+    // Write the final mono PCM to the pipe
+    if (buffer_to_write != nullptr && !buffer_to_write->empty())
+    {
+        if (!writePcmToPipe(*buffer_to_write))
+        {
+            // Error writing to pipe, likely closed. Stop processing loop.
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void BackchannelProcessor::run()
+{
+    if (!global_backchannel)
+    {
+        LOG_ERROR("Cannot run BackchannelProcessor: global_backchannel is null.");
+        return;
+    }
+
+    LOG_INFO("Processor thread running...");
+
+    global_backchannel->running = true;
+    while (global_backchannel->running)
+    {
+        // Wait for condition: running and at least one sink is sending
+        {
+            std::unique_lock<std::mutex> lock(global_backchannel->mutex);
+            global_backchannel->should_grab_frames.wait(lock, [&] {
+                return !global_backchannel->running
+                       || global_backchannel->is_sending.load(std::memory_order_acquire) > 0;
+            });
+        }
+
+        if (!global_backchannel->running)
+        {
+            break;
+        }
+
+        BackchannelFrame frame = global_backchannel->inputQueue->wait_read();
+
+        if (!global_backchannel->running)
+        {
+            break;
+        }
+
+        // Handle Zero-Payload Frame (Stop Signal)
+        if (frame.payload.empty())
+        {
+            LOG_DEBUG("Received stop signal (zero-payload) from session " << frame.clientSessionId);
+            if (frame.clientSessionId == currentSessionId && currentSessionId != 0)
+            {
+                LOG_INFO("Current session " << currentSessionId << " stopped. Closing pipe.");
+                closePipe();
+                currentSessionId = 0;
+            }
+            else if (currentSessionId == 0)
+            {
+                LOG_DEBUG("Stop signal received but no current session. Ignoring.");
+            }
+            else
+            {
+                LOG_WARN("Stop signal from non-current session "
+                         << frame.clientSessionId << " (Current: " << currentSessionId
+                         << "). Ignoring.");
+            }
+            continue;
+        }
+
+        // Handle Playback Frame (Data)
+        if (currentSessionId == 0)
+        {
+            // No current session, this frame's sender becomes the current one
+            currentSessionId = frame.clientSessionId;
+            LOG_INFO("New current session " << currentSessionId << " playing "
+                                            << getFormatName(frame.format) << ". Opening pipe.");
+            if (!initPipe())
+            {
+                LOG_ERROR("Failed to open pipe for new session " << currentSessionId
+                                                                 << ". Resetting.");
+                currentSessionId = 0;
+                continue;
+            }
+            // Pipe is open
+            if (!processFrame(frame))
+            {
+                // processFrame returns false if pipe write fails and closes pipe
+                LOG_WARN("processFrame failed for initial frame of session " << currentSessionId
+                                                                             << ". Pipe closed.");
+                currentSessionId = 0;
+            }
+        }
+        else if (frame.clientSessionId == currentSessionId)
+        {
+            // Frame is from the current session
+            if (!fPipe)
+            { // Ensure pipe is open (it might have closed unexpectedly)
+                LOG_WARN("Pipe was closed unexpectedly for current session " << currentSessionId
+                                                                             << ". Reopening.");
+                if (!initPipe())
+                {
+                    LOG_ERROR("Failed to reopen pipe for session " << currentSessionId
+                                                                   << ". Resetting.");
+                    currentSessionId = 0;
+                    continue;
+                }
+            }
+            // Pipe should be open
+            if (!processFrame(frame))
+            {
+                // processFrame returns false if pipe write fails and closes pipe
+                LOG_WARN("processFrame failed for session " << currentSessionId << ". Pipe closed.");
+                currentSessionId = 0;
+            }
+        }
+        else
+        {
+            // Frame is from a different session, ignore it
+            LOG_DEBUG("Discarding frame from non-current session "
+                      << frame.clientSessionId << " (Current: " << currentSessionId << ")");
+        }
+    }
+
+    LOG_INFO("Processor thread stopping.");
+    closePipe();
+}

--- a/src/BackchannelProcessor.hpp
+++ b/src/BackchannelProcessor.hpp
@@ -1,0 +1,45 @@
+#ifndef BACKCHANNEL_PROCESSOR_HPP
+#define BACKCHANNEL_PROCESSOR_HPP
+
+// Processes audio frames, decodes them, handles session management (who is
+// "current"), resamples, and sends PCM data to a pipe.
+
+#include "IMPBackchannel.hpp"
+#include "globals.hpp"
+
+#include <cstdint>
+#include <cstdio>
+
+class BackchannelProcessor
+{
+public:
+    BackchannelProcessor();
+    ~BackchannelProcessor();
+
+    void run();
+
+private:
+    std::vector<int16_t> resampleLinear(const std::vector<int16_t> &input_pcm,
+                                        int input_rate,
+                                        int output_rate);
+
+    bool initPipe();
+    void closePipe();
+
+    bool processFrame(const BackchannelFrame &frame);
+    bool decodeFrame(const uint8_t *payload,
+                     size_t payloadSize,
+                     IMPBackchannelFormat format,
+                     std::vector<int16_t> &outPcmBuffer);
+    bool writePcmToPipe(const std::vector<int16_t> &pcmBuffer);
+
+    unsigned int currentSessionId;
+
+    FILE *fPipe;
+    int fPipeFd;
+
+    BackchannelProcessor(const BackchannelProcessor &) = delete;
+    BackchannelProcessor &operator=(const BackchannelProcessor &) = delete;
+};
+
+#endif // BACKCHANNEL_PROCESSOR_HPP

--- a/src/BackchannelServerMediaSubsession.cpp
+++ b/src/BackchannelServerMediaSubsession.cpp
@@ -1,0 +1,408 @@
+#include "BackchannelServerMediaSubsession.hpp"
+
+#include "BackchannelSink.hpp"
+#include "BackchannelStreamState.hpp"
+#include "Config.hpp"
+#include "IMPBackchannel.hpp"
+#include "Logger.hpp"
+#include "globals.hpp"
+
+#include <GroupsockHelper.hh>
+
+#define MODULE "BackchannelSubsession"
+
+BackchannelServerMediaSubsession *BackchannelServerMediaSubsession::createNew(
+    UsageEnvironment &env, IMPBackchannelFormat format)
+{
+    return new BackchannelServerMediaSubsession(env, format);
+}
+
+BackchannelServerMediaSubsession::BackchannelServerMediaSubsession(UsageEnvironment &env,
+                                                                   IMPBackchannelFormat format)
+    : OnDemandServerMediaSubsession(env, False)
+    , fSDPLines(nullptr)
+    , fInitialPortNum(6970)
+    , fMultiplexRTCPWithRTP(false)
+    , fFormat(format)
+{
+    LOG_DEBUG("Subsession created for channel " << static_cast<int>(fFormat));
+    gethostname(fCNAME, MAX_CNAME_LEN);
+    fCNAME[MAX_CNAME_LEN] = '\0';
+
+    // Adjust initial port number for RTCP if not multiplexing
+    if (!fMultiplexRTCPWithRTP)
+    {
+        fInitialPortNum = (fInitialPortNum + 1) & ~1;
+    }
+}
+
+BackchannelServerMediaSubsession::~BackchannelServerMediaSubsession()
+{
+    LOG_DEBUG("Subsession destroyed");
+    delete[] fSDPLines;
+}
+
+char const *BackchannelServerMediaSubsession::sdpLines(int /*addressFamily*/)
+{
+    if (fSDPLines == nullptr)
+    {
+        unsigned int sdpLinesSize = 400;
+        fSDPLines = new char[sdpLinesSize];
+        if (fSDPLines == nullptr)
+            return nullptr;
+
+        const char *formatName;
+        int payloadType;
+        unsigned frequency;
+
+#define APPLY_SDP_IF(EnumName, NameString, PayloadType, Frequency, MimeType) \
+    if (fFormat == IMPBackchannelFormat::EnumName) \
+    { \
+        formatName = NameString; \
+        payloadType = PayloadType; \
+        frequency = Frequency; \
+    }
+
+        X_FOREACH_BACKCHANNEL_FORMAT(APPLY_SDP_IF)
+#undef APPLY_SDP_IF
+
+        LOG_DEBUG("Generating SDP for format " << formatName << " (Payload Type: " << payloadType
+                                               << ")");
+
+        snprintf(fSDPLines,
+                 sdpLinesSize,
+                 "m=audio 0 RTP/AVP %d\r\n"
+                 "c=IN IP4 0.0.0.0\r\n"
+                 "b=AS:%u\r\n"
+                 "a=rtpmap:%d %s/%u/%d\r\n"
+                 "a=control:%s\r\n"
+                 "a=sendonly\r\n",
+                 payloadType,
+                 estimatedBitrate(),
+                 payloadType,
+                 formatName,
+                 frequency,
+                 1,
+                 trackId());
+
+        fSDPLines[sdpLinesSize - 1] = '\0'; // Ensure null termination
+    }
+    return fSDPLines;
+}
+
+char const *BackchannelServerMediaSubsession::getAuxSDPLine(RTPSink * /*rtpSink*/,
+                                                            FramedSource * /*inputSource*/)
+{
+    // No auxiliary SDP line needed
+    return nullptr;
+}
+
+MediaSink *BackchannelServerMediaSubsession::createNewStreamDestination(unsigned clientSessionId,
+                                                                        unsigned & /*estBitrate*/)
+{
+    LOG_DEBUG("Creating BackchannelSink for channel: " << static_cast<int>(fFormat));
+    return BackchannelSink::createNew(envir(), clientSessionId, fFormat);
+}
+
+RTPSource *BackchannelServerMediaSubsession::createNewRTPSource(
+    Groupsock *rtpGroupsock, unsigned char /*rtpPayloadTypeIfDynamic*/, MediaSink * /*outputSink*/)
+{
+    const char *mimeType;
+    int payloadType;
+    unsigned frequency;
+
+#define APPLY_SOURCE_IF(EnumName, NameString, PayloadType, Frequency, MimeType) \
+    if (fFormat == IMPBackchannelFormat::EnumName) \
+    { \
+        mimeType = MimeType; \
+        payloadType = PayloadType; \
+        frequency = Frequency; \
+    }
+    X_FOREACH_BACKCHANNEL_FORMAT(APPLY_SOURCE_IF)
+#undef APPLY_SOURCE_IF
+
+    return SimpleRTPSource::createNew(envir(),
+                                      rtpGroupsock,
+                                      payloadType,
+                                      frequency,
+                                      mimeType,
+                                      0,      // numChannels - currently always 0
+                                      False); // allowMultipleFramesPerPacket
+}
+
+void BackchannelServerMediaSubsession::getStreamParameters(
+    unsigned clientSessionId,
+    struct sockaddr_storage const &clientAddress,
+    Port const &clientRTPPort,
+    Port const &clientRTCPPort,
+    int tcpSocketNum,
+    unsigned char rtpChannelId,
+    unsigned char rtcpChannelId,
+    TLSState *tlsState,
+    struct sockaddr_storage &destinationAddress,
+    u_int8_t & /*destinationTTL*/,
+    Boolean &isMulticast,
+    Port &serverRTPPort,
+    Port &serverRTCPPort,
+    void *&streamToken)
+{
+    isMulticast = False; // This subsession is always unicast
+    streamToken = nullptr;
+
+    // Set destination address if not provided by client
+    if (addressIsNull(destinationAddress))
+    {
+        destinationAddress = clientAddress;
+    }
+
+    // Validate transport parameters
+    if (clientRTPPort.num() == 0 && tcpSocketNum < 0)
+    {
+        LOG_ERROR(
+            "getStreamParameters: Invalid parameters (no client ports or TCP socket) for session "
+            << clientSessionId);
+        return;
+    }
+
+    // Create MediaSink
+    unsigned streamBitrate = 0;
+    MediaSink *mediaSink = createNewStreamDestination(clientSessionId, streamBitrate);
+    if (mediaSink == nullptr)
+    {
+        LOG_ERROR("getStreamParameters: createNewStreamDestination FAILED for session "
+                  << clientSessionId);
+        return;
+    }
+
+    // Initialize transport variables
+    Groupsock *rtpGroupsock = nullptr;
+    Groupsock *rtcpGroupsock = nullptr;
+    Boolean isTCP = (tcpSocketNum >= 0);
+
+    // Set up transport (UDP or TCP) and create Groupsocks
+    if (!isTCP)
+    { // UDP
+        if (clientRTCPPort.num() == 0)
+        {
+            // This might be okay if the client doesn't intend to send RTCP Sender Reports
+            LOG_WARN("Client requested UDP streaming but provided no RTCP port for session "
+                     << clientSessionId);
+        }
+
+        // Allocate UDP ports and create groupsocks
+        if (!allocateUdpPorts(serverRTPPort, serverRTCPPort, rtpGroupsock, rtcpGroupsock))
+        {
+            LOG_ERROR("getStreamParameters: Failed to allocate UDP ports for session "
+                      << clientSessionId);
+            Medium::close(mediaSink);
+            // allocateUdpPorts cleans up its own groupsocks on failure
+            return;
+        }
+    }
+    else
+    { // TCP
+        serverRTPPort = 0;
+        serverRTCPPort = 0;
+        struct sockaddr_storage dummyAddr;
+        memset(&dummyAddr, 0, sizeof dummyAddr);
+        dummyAddr.ss_family = AF_INET;
+        Port dummyPort(0);
+
+        // Create dummy groupsocks
+        rtpGroupsock = new Groupsock(envir(), dummyAddr, dummyPort, 0);
+        if (rtpGroupsock == nullptr || rtpGroupsock->socketNum() < 0)
+        {
+            LOG_ERROR("getStreamParameters: Failed to create dummy RTP Groupsock for TCP session "
+                      << clientSessionId);
+            Medium::close(mediaSink);
+            delete rtpGroupsock; // Safe even if null
+            return;
+        }
+
+        rtcpGroupsock = new Groupsock(envir(), dummyAddr, dummyPort, 0);
+        if (rtcpGroupsock == nullptr || rtcpGroupsock->socketNum() < 0)
+        {
+            LOG_ERROR("getStreamParameters: Failed to create dummy RTCP Groupsock for TCP session "
+                      << clientSessionId);
+            Medium::close(mediaSink);
+            delete rtpGroupsock;
+            delete rtcpGroupsock; // Safe even if null
+            return;
+        }
+    }
+
+    // Create the RTPSource (which receives data) using the established groupsock
+    RTPSource *rtpSource = createNewRTPSource(rtpGroupsock, 0, mediaSink);
+    if (rtpSource == nullptr)
+    {
+        LOG_ERROR("getStreamParameters: createNewRTPSource FAILED for session " << clientSessionId);
+        Medium::close(mediaSink);
+        delete rtpGroupsock;
+        if (rtcpGroupsock != rtpGroupsock) // Avoid double delete if multiplexing
+            delete rtcpGroupsock;
+        return;
+    }
+
+    // Create our custom stream state object
+    BackchannelStreamState *state = new BackchannelStreamState(envir(),
+                                                               fCNAME,
+                                                               rtpSource,
+                                                               (BackchannelSink *) mediaSink,
+                                                               rtpGroupsock,
+                                                               rtcpGroupsock,
+                                                               clientSessionId,
+                                                               destinationAddress,
+                                                               clientRTPPort,
+                                                               clientRTCPPort,
+                                                               tcpSocketNum,
+                                                               rtpChannelId,
+                                                               rtcpChannelId,
+                                                               tlsState);
+
+    if (state == nullptr)
+    {
+        LOG_ERROR("getStreamParameters: Failed to create BackchannelStreamState for session "
+                  << clientSessionId);
+        Medium::close(rtpSource);
+        Medium::close(mediaSink);
+        delete rtpGroupsock;
+        if (rtcpGroupsock != rtpGroupsock)
+            delete rtcpGroupsock;
+        return;
+    }
+
+    // Success: Assign the state object to the stream token
+    streamToken = (void *) state;
+}
+
+bool BackchannelServerMediaSubsession::allocateUdpPorts(Port &serverRTPPort,
+                                                        Port &serverRTCPPort,
+                                                        Groupsock *&rtpGroupsock,
+                                                        Groupsock *&rtcpGroupsock)
+{
+    NoReuse dummy(envir());
+    portNumBits serverPortNum = fInitialPortNum;
+
+    while (1)
+    {
+        serverRTPPort = serverPortNum;
+        struct sockaddr_storage nullAddr;
+        memset(&nullAddr, 0, sizeof(nullAddr));
+        nullAddr.ss_family = AF_INET;
+        rtpGroupsock = createGroupsock(nullAddr, serverRTPPort);
+        if (rtpGroupsock->socketNum() < 0)
+        {
+            delete rtpGroupsock;
+            rtpGroupsock = nullptr;
+            serverPortNum += (fMultiplexRTCPWithRTP ? 1 : 2);
+            if (serverPortNum == 0)
+                return False; // Port wrap-around check
+            continue;
+        }
+
+        if (fMultiplexRTCPWithRTP)
+        {
+            serverRTCPPort = serverRTPPort;
+            rtcpGroupsock = rtpGroupsock;
+        }
+        else
+        {
+            serverRTCPPort = ++serverPortNum;
+            if (serverPortNum == 0)
+            { // Port wrap-around check
+                delete rtpGroupsock;
+                rtpGroupsock = nullptr;
+                return False;
+            }
+            rtcpGroupsock = createGroupsock(nullAddr, serverRTCPPort);
+            if (rtcpGroupsock->socketNum() < 0)
+            {
+                delete rtpGroupsock;
+                rtpGroupsock = nullptr;
+                delete rtcpGroupsock;
+                rtcpGroupsock = nullptr;
+                ++serverPortNum; // Port pair failed, try next
+                if (serverPortNum == 0)
+                    return False; // Port wrap-around check
+                continue;
+            }
+        }
+        LOG_DEBUG("UDP port allocation succeeded. RTP=" << ntohs(serverRTPPort.num()) << ", RTCP="
+                                                        << ntohs(serverRTCPPort.num()));
+        return True; // Success
+    }
+}
+
+void BackchannelServerMediaSubsession::startStream(
+    unsigned clientSessionId,
+    void *streamToken,
+    TaskFunc *rtcpRRHandler,
+    void *rtcpRRHandlerClientData,
+    unsigned short &rtpSeqNum,
+    unsigned &rtpTimestamp,
+    ServerRequestAlternativeByteHandler *serverRequestAlternativeByteHandler,
+    void *serverRequestAlternativeByteHandlerClientData)
+{
+    BackchannelStreamState *state = (BackchannelStreamState *) streamToken;
+
+    if (state == nullptr)
+    {
+        LOG_DEBUG("Client setup/probe initiated (NULL streamToken) for session " << clientSessionId);
+        return;
+    }
+
+    state->startPlaying(rtcpRRHandler,
+                        rtcpRRHandlerClientData,
+                        serverRequestAlternativeByteHandler,
+                        serverRequestAlternativeByteHandlerClientData);
+
+    // Set initial RTP seq num and timestamp
+    rtpSeqNum = 0;
+    rtpTimestamp = 0;
+    RTPSource *rtpSource = state->rtpSource;
+    if (rtpSource != nullptr)
+    {
+        rtpSeqNum = rtpSource->curPacketMarkerBit() ? (rtpSource->curPacketRTPSeqNum() + 1)
+                                                    : rtpSource->curPacketRTPSeqNum();
+    }
+}
+
+void BackchannelServerMediaSubsession::deleteStream(unsigned clientSessionId, void *&streamToken)
+{
+    BackchannelStreamState *state = (BackchannelStreamState *) streamToken;
+    if (state != nullptr)
+    {
+        // Deleting the state object triggers its destructor for cleanup
+        delete state;
+        streamToken = nullptr;
+    }
+}
+
+void BackchannelServerMediaSubsession::getRTPSinkandRTCP(void *streamToken,
+                                                         RTPSink *&rtpSink,
+                                                         RTCPInstance *&rtcp)
+{
+    // This subsession only receives, so no RTPSink or RTCP for sending.
+    rtpSink = nullptr;
+    rtcp = nullptr;
+}
+
+int BackchannelServerMediaSubsession::estimatedBitrate()
+{
+    return 64;
+}
+
+FramedSource *BackchannelServerMediaSubsession::createNewStreamSource(unsigned /*clientSessionId*/,
+                                                                      unsigned & /*estBitrate */)
+{
+    // This subsession receives, it doesn't provide a source to an RTPSink.
+    return nullptr;
+}
+
+RTPSink *BackchannelServerMediaSubsession::createNewRTPSink(Groupsock * /*rtpGroupsock*/,
+                                                            unsigned char /*rtpPayloadTypeIfDynamic*/,
+                                                            FramedSource * /*inputSource*/)
+{
+    // This subsession receives, it doesn't create an RTPSink for sending.
+    return nullptr;
+}

--- a/src/BackchannelServerMediaSubsession.hpp
+++ b/src/BackchannelServerMediaSubsession.hpp
@@ -1,0 +1,81 @@
+#ifndef BACKCHANNEL_SERVER_MEDIA_SUBSESSION_HPP
+#define BACKCHANNEL_SERVER_MEDIA_SUBSESSION_HPP
+
+// Handles the server side of a backchannel audio stream within an RTSP session,
+// creating the sink, managing stream parameters, and handling a single format
+// for all clients.
+
+#define MAX_CNAME_LEN 100
+
+#include "BackchannelSink.hpp"
+#include "BackchannelStreamState.hpp"
+#include "IMPBackchannel.hpp"
+
+#include <liveMedia.hh>
+
+class BackchannelServerMediaSubsession : public OnDemandServerMediaSubsession
+{
+    friend class BackchannelStreamState;
+
+public:
+    static BackchannelServerMediaSubsession *createNew(UsageEnvironment &env,
+                                                       IMPBackchannelFormat format);
+
+    virtual ~BackchannelServerMediaSubsession();
+
+protected:
+    BackchannelServerMediaSubsession(UsageEnvironment &env, IMPBackchannelFormat format);
+
+    virtual char const *sdpLines(int addressFamily);
+    virtual char const *getAuxSDPLine(RTPSink *rtpSink, FramedSource *inputSource);
+
+    virtual MediaSink *createNewStreamDestination(unsigned clientSessionId, unsigned &estBitrate);
+    virtual RTPSource *createNewRTPSource(Groupsock *rtpGroupsock,
+                                          unsigned char rtpPayloadTypeIfDynamic,
+                                          MediaSink *outputSink);
+    virtual void getStreamParameters(unsigned clientSessionId,
+                                     struct sockaddr_storage const &clientAddress,
+                                     Port const &clientRTPPort,
+                                     Port const &clientRTCPPort,
+                                     int tcpSocketNum,
+                                     unsigned char rtpChannelId,
+                                     unsigned char rtcpChannelId,
+                                     TLSState *tlsState,
+                                     struct sockaddr_storage &destinationAddress,
+                                     u_int8_t &destinationTTL,
+                                     Boolean &isMulticast,
+                                     Port &serverRTPPort,
+                                     Port &serverRTCPPort,
+                                     void *&streamToken);
+
+    virtual void startStream(unsigned clientSessionId,
+                             void *streamToken,
+                             TaskFunc *rtcpRRHandler,
+                             void *rtcpRRHandlerClientData,
+                             unsigned short &rtpSeqNum,
+                             unsigned &rtpTimestamp,
+                             ServerRequestAlternativeByteHandler *serverRequestAlternativeByteHandler,
+                             void *serverRequestAlternativeByteHandlerClientData);
+    virtual void deleteStream(unsigned clientSessionId, void *&streamToken);
+
+    virtual void getRTPSinkandRTCP(void *streamToken, RTPSink *&rtpSink, RTCPInstance *&rtcp);
+    virtual FramedSource *createNewStreamSource(unsigned clientSessionId, unsigned &estBitrate);
+    virtual RTPSink *createNewRTPSink(Groupsock *rtpGroupsock,
+                                      unsigned char rtpPayloadTypeIfDynamic,
+                                      FramedSource *inputSource);
+
+private:
+    bool allocateUdpPorts(Port &serverRTPPort,
+                          Port &serverRTCPPort,
+                          Groupsock *&rtpGroupsock,
+                          Groupsock *&rtcpGroupsock);
+    int estimatedBitrate();
+
+    char *fSDPLines = nullptr;      // Cached SDP lines
+    char fCNAME[MAX_CNAME_LEN + 1]; // For RTCP
+    portNumBits fInitialPortNum;    // Starting port for UDP allocation
+    bool fMultiplexRTCPWithRTP;     // Whether to multiplex RTCP with RTP
+    IMPBackchannelFormat fFormat;   // Audio format for this subsession
+};
+
+#endif // BACKCHANNEL_SERVER_MEDIA_SUBSESSION_HPP

--- a/src/BackchannelSink.cpp
+++ b/src/BackchannelSink.cpp
@@ -1,0 +1,249 @@
+#include "BackchannelSink.hpp"
+
+#include "Logger.hpp"
+#include "globals.hpp"
+
+#define MODULE "BackchannelSink"
+
+#define TIMEOUT_MICROSECONDS 500000 // Timeout set to 500ms
+
+BackchannelSink *BackchannelSink::createNew(UsageEnvironment &env,
+                                            unsigned clientSessionId,
+                                            IMPBackchannelFormat format)
+{
+    return new BackchannelSink(env, clientSessionId, format);
+}
+
+BackchannelSink::BackchannelSink(UsageEnvironment &env,
+                                 unsigned clientSessionId,
+                                 IMPBackchannelFormat format)
+    : MediaSink(env)
+    , fRTPSource(nullptr)
+    , fReceiveBufferSize(1024)
+    , fIsActive(false)
+    , fAfterFunc(nullptr)
+    , fAfterClientData(nullptr)
+    , fClientSessionId(clientSessionId)
+    , fTimeoutTask(nullptr)
+    , fIsSending(false)
+    , fFormat(format)
+{
+    fReceiveBuffer = new u_int8_t[fReceiveBufferSize];
+    if (fReceiveBuffer == nullptr)
+    {
+        LOG_ERROR("Failed to allocate receive buffer (Session: " << fClientSessionId << ")");
+    }
+}
+
+BackchannelSink::~BackchannelSink()
+{
+    sendBackchannelStopFrame();
+    delete[] fReceiveBuffer;
+}
+
+Boolean BackchannelSink::startPlaying(FramedSource &source,
+                                      MediaSink::afterPlayingFunc *afterFunc,
+                                      void *afterClientData)
+{
+    if (fIsActive)
+    {
+        LOG_WARN("startPlaying called while already active for session " << fClientSessionId);
+        return False;
+    }
+
+    fRTPSource = &source;
+    fAfterFunc = afterFunc;
+    fAfterClientData = afterClientData;
+    fIsActive = True;
+
+    LOG_DEBUG("Sink starting consumption for session " << fClientSessionId);
+
+    return continuePlaying();
+}
+
+void BackchannelSink::stopPlaying()
+{
+    if (!fIsActive)
+    {
+        return;
+    }
+
+    LOG_DEBUG("Sink stopping consumption for session " << fClientSessionId);
+
+    // Set inactive *first* to prevent re-entrancy
+    fIsActive = False;
+
+    sendBackchannelStopFrame();
+
+    envir().taskScheduler().unscheduleDelayedTask(fTimeoutTask);
+    fTimeoutTask = nullptr;
+
+    if (fRTPSource != nullptr)
+    {
+        fRTPSource->stopGettingFrames();
+    }
+
+    if (fAfterFunc != nullptr)
+    {
+        (*fAfterFunc)(fAfterClientData);
+    }
+
+    fRTPSource = nullptr;
+    fAfterFunc = nullptr;
+    fAfterClientData = nullptr;
+}
+
+Boolean BackchannelSink::continuePlaying()
+{
+    if (!fIsActive || fRTPSource == nullptr)
+    {
+        return False;
+    }
+
+    fRTPSource
+        ->getNextFrame(fReceiveBuffer, fReceiveBufferSize, afterGettingFrame, this, nullptr, this);
+
+    return True;
+}
+
+void BackchannelSink::afterGettingFrame(void *clientData,
+                                        unsigned frameSize,
+                                        unsigned numTruncatedBytes,
+                                        struct timeval presentationTime,
+                                        unsigned /*durationInMicroseconds*/)
+{
+    BackchannelSink *sink = static_cast<BackchannelSink *>(clientData);
+    if (sink != nullptr)
+    {
+        sink->afterGettingFrame1(frameSize, numTruncatedBytes, presentationTime);
+    }
+    else
+    {
+        LOG_ERROR("afterGettingFrame called with invalid clientData");
+    }
+}
+
+void BackchannelSink::afterGettingFrame1(unsigned frameSize,
+                                         unsigned numTruncatedBytes,
+                                         struct timeval presentationTime)
+{
+    if (!fIsActive)
+    {
+        return;
+    }
+
+    if (numTruncatedBytes > 0)
+    {
+        LOG_WARN("Received truncated frame (" << frameSize << " bytes, " << numTruncatedBytes
+                                              << " truncated) for session " << fClientSessionId
+                                              << ". Discarding.");
+    }
+    else if (frameSize > 0)
+    {
+        sendBackchannelFrame(fReceiveBuffer, frameSize);
+    }
+
+    // Reschedule the timeout check after receiving any frame (even size 0 or
+    // truncated) This resets the timer as long as *something* is coming from the
+    // source.
+    envir().taskScheduler().unscheduleDelayedTask(fTimeoutTask);
+    scheduleTimeoutCheck();
+
+    if (fIsActive)
+    {
+        continuePlaying();
+    }
+}
+
+void BackchannelSink::scheduleTimeoutCheck()
+{
+    fTimeoutTask = envir().taskScheduler().scheduleDelayedTask(TIMEOUT_MICROSECONDS,
+                                                               (TaskFunc *) timeoutCheck,
+                                                               this);
+}
+
+void BackchannelSink::timeoutCheck(void *clientData)
+{
+    BackchannelSink *sink = static_cast<BackchannelSink *>(clientData);
+    if (sink)
+    {
+        sink->timeoutCheck1();
+    }
+}
+
+void BackchannelSink::timeoutCheck1()
+{
+    fTimeoutTask = nullptr;
+
+    if (!fIsActive)
+    {
+        return;
+    }
+
+    LOG_INFO("Audio data timeout detected for session " << fClientSessionId
+                                                        << ". Sending stop frame.");
+    sendBackchannelStopFrame();
+}
+
+void BackchannelSink::sendBackchannelFrame(const uint8_t *payload, unsigned payloadSize)
+{
+    if (!global_backchannel)
+    {
+        LOG_ERROR("global_backchannel is null, cannot queue BackchannelFrame! (Session: "
+                  << fClientSessionId << ")");
+        return;
+    }
+
+    if (!fIsSending)
+    {
+        fIsSending = true;
+        global_backchannel->is_sending.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    BackchannelFrame bcFrame;
+    bcFrame.format = fFormat;
+    bcFrame.clientSessionId = fClientSessionId;
+    bcFrame.payload.assign(payload, payload + payloadSize);
+
+    if (!global_backchannel->inputQueue->write(std::move(bcFrame)))
+    {
+        LOG_WARN("Input queue full for session " << fClientSessionId << ". Frame dropped.");
+    }
+    else
+    {
+        global_backchannel->should_grab_frames.notify_one();
+    }
+}
+
+void BackchannelSink::sendBackchannelStopFrame()
+{
+    if (!fIsSending)
+    {
+        return;
+    }
+
+    if (global_backchannel)
+    {
+        BackchannelFrame stopFrame;
+        stopFrame.format = fFormat;
+        stopFrame.clientSessionId = fClientSessionId;
+        stopFrame.payload.clear(); // Zero-size payload indicates stop/timeout
+        if (!global_backchannel->inputQueue->write(std::move(stopFrame)))
+        {
+            LOG_WARN("Input queue full when trying to send stop frame for session "
+                     << fClientSessionId);
+        }
+        else
+        {
+            global_backchannel->should_grab_frames.notify_one();
+            fIsSending = false;
+            global_backchannel->is_sending.fetch_sub(1, std::memory_order_relaxed);
+            LOG_INFO("Sent stop frame (zero-payload frame) for session " << fClientSessionId);
+        }
+    }
+    else
+    {
+        LOG_ERROR("global_backchannel is null, cannot send stop frame for session "
+                  << fClientSessionId);
+    }
+}

--- a/src/BackchannelSink.hpp
+++ b/src/BackchannelSink.hpp
@@ -1,0 +1,63 @@
+#ifndef BACKCHANNEL_SINK_HPP
+#define BACKCHANNEL_SINK_HPP
+
+// Receives audio data, encapsulates it in BackchannelFrame, enqueues it, and
+// handles inactivity timeouts by sending stop frames.
+
+#include "IMPBackchannel.hpp"
+#include "Logger.hpp"
+
+#include <cstdint>
+#include <liveMedia.hh>
+
+class BackchannelSink : public MediaSink
+{
+public:
+    static BackchannelSink *createNew(UsageEnvironment &env,
+                                      unsigned clientSessionId,
+                                      IMPBackchannelFormat format);
+
+    Boolean startPlaying(FramedSource &source,
+                         MediaSink::afterPlayingFunc *afterFunc,
+                         void *afterClientData);
+    void stopPlaying();
+
+protected:
+    BackchannelSink(UsageEnvironment &env, unsigned clientSessionId, IMPBackchannelFormat format);
+    virtual ~BackchannelSink();
+
+    virtual Boolean continuePlaying();
+
+private:
+    void scheduleTimeoutCheck();
+    static void timeoutCheck(void *clientData);
+    void timeoutCheck1();
+
+    static void afterGettingFrame(void *clientData,
+                                  unsigned frameSize,
+                                  unsigned numTruncatedBytes,
+                                  struct timeval presentationTime,
+                                  unsigned durationInMicroseconds);
+    void afterGettingFrame1(unsigned frameSize,
+                            unsigned numTruncatedBytes,
+                            struct timeval presentationTime);
+
+    void sendBackchannelFrame(const uint8_t *payload, unsigned payloadSize);
+    void sendBackchannelStopFrame();
+
+    FramedSource *fRTPSource;
+    u_int8_t *fReceiveBuffer;
+    int fReceiveBufferSize;
+
+    bool fIsActive;
+    MediaSink::afterPlayingFunc *fAfterFunc;
+    void *fAfterClientData;
+
+    unsigned fClientSessionId;
+    TaskToken fTimeoutTask;
+
+    bool fIsSending;
+    const IMPBackchannelFormat fFormat;
+};
+
+#endif // BACKCHANNEL_SINK_HPP

--- a/src/BackchannelStreamState.cpp
+++ b/src/BackchannelStreamState.cpp
@@ -1,0 +1,157 @@
+#include "BackchannelStreamState.hpp"
+
+#include "Logger.hpp"
+
+#define MODULE "BackchannelStreamState"
+
+BackchannelStreamState::BackchannelStreamState(UsageEnvironment &env,
+                                               char const *cname,
+                                               RTPSource *_rtpSource,
+                                               BackchannelSink *_mediaSink,
+                                               Groupsock *_rtpGS,
+                                               Groupsock *_rtcpGS,
+                                               unsigned _clientSessionId,
+                                               struct sockaddr_storage const &_destAddr,
+                                               Port const &_rtpDestPort,
+                                               Port const &_rtcpDestPort,
+                                               int _tcpSocketNum,
+                                               unsigned char _rtpChannelId,
+                                               unsigned char _rtcpChannelId,
+                                               TLSState *_tlsState)
+    : fEnv(env)
+    , fCNAME(cname)
+    , rtpSource(_rtpSource)
+    , mediaSink(_mediaSink)
+    , rtpGS(_rtpGS)
+    , rtcpGS(_rtcpGS)
+    , rtcpInstance(nullptr)
+    , clientSessionId(_clientSessionId)
+    , fIsTCP(_tcpSocketNum >= 0)
+{
+    // Initialize the appropriate part of the transport union
+    if (fIsTCP)
+    {
+        fTransport.t.tcpSocketNum = _tcpSocketNum;
+        fTransport.t.rtpChannelId = _rtpChannelId;
+        fTransport.t.rtcpChannelId = _rtcpChannelId;
+        fTransport.t.tlsState = _tlsState;
+    }
+    else
+    {
+        fTransport.u.destAddr = _destAddr;
+        fTransport.u.rtpDestPort = _rtpDestPort;
+        fTransport.u.rtcpDestPort = _rtcpDestPort;
+    }
+}
+BackchannelStreamState::~BackchannelStreamState()
+{
+    LOG_DEBUG("Destroyed for session " << clientSessionId);
+    Medium::close(rtcpInstance);
+    Medium::close(rtpSource);
+    Medium::close(mediaSink);
+
+    // Delete groupsocks
+    delete rtpGS;
+    if (rtcpGS != nullptr && rtcpGS != rtpGS)
+    { // Avoid double delete if multiplexing
+        delete rtcpGS;
+    }
+}
+
+void BackchannelStreamState::startPlaying(
+    TaskFunc *rtcpRRHandler,
+    void *rtcpRRHandlerClientData,
+    ServerRequestAlternativeByteHandler *serverRequestAlternativeByteHandler,
+    void *serverRequestAlternativeByteHandlerClientData)
+{
+    if (mediaSink && rtpSource)
+    {
+        // Create RTCP instance using stored env and CNAME
+        rtcpInstance = RTCPInstance::createNew(fEnv,
+                                               rtcpGS,
+                                               64 /*est BW kbps*/,
+                                               (unsigned char *) fCNAME,
+                                               nullptr /*sink*/,
+                                               rtpSource /*source*/,
+                                               True /*is server*/);
+        if (rtcpInstance)
+        {
+            rtcpInstance->setRRHandler(rtcpRRHandler, rtcpRRHandlerClientData);
+
+            // Configure transport based on stored flag and union data
+            if (fIsTCP)
+            {
+                LOG_INFO("Configuring stream for TCP (session "
+                         << clientSessionId << ", socket " << fTransport.t.tcpSocketNum
+                         << ", RTP ch " << (int) fTransport.t.rtpChannelId << ", RTCP ch "
+                         << (int) fTransport.t.rtcpChannelId << ")");
+                rtpSource->setStreamSocket(fTransport.t.tcpSocketNum,
+                                           fTransport.t.rtpChannelId,
+                                           fTransport.t.tlsState);
+                rtcpInstance->addStreamSocket(fTransport.t.tcpSocketNum,
+                                              fTransport.t.rtcpChannelId,
+                                              fTransport.t.tlsState);
+
+                // Use stored env
+                RTPInterface::setServerRequestAlternativeByteHandler(
+                    fEnv,
+                    fTransport.t.tcpSocketNum,
+                    serverRequestAlternativeByteHandler,
+                    serverRequestAlternativeByteHandlerClientData);
+
+                // Set specific RR handler for TCP
+                struct sockaddr_storage tcpSocketNumAsAddress;
+                memset(&tcpSocketNumAsAddress, 0, sizeof(tcpSocketNumAsAddress));
+                tcpSocketNumAsAddress.ss_family = AF_INET;
+                ((struct sockaddr_in &) tcpSocketNumAsAddress).sin_addr.s_addr = htonl(
+                    fTransport.t.tcpSocketNum);
+                rtcpInstance->setSpecificRRHandler(tcpSocketNumAsAddress,
+                                                   fTransport.t.rtcpChannelId,
+                                                   rtcpRRHandler,
+                                                   rtcpRRHandlerClientData);
+            }
+            else
+            { // UDP
+                LOG_INFO("Configuring stream for UDP (session " << clientSessionId << ")");
+                if (rtpGS)
+                    rtpGS->addDestination(fTransport.u.destAddr,
+                                          fTransport.u.rtpDestPort,
+                                          clientSessionId);
+                if (rtcpGS)
+                    rtcpGS->addDestination(fTransport.u.destAddr,
+                                           fTransport.u.rtcpDestPort,
+                                           clientSessionId);
+                rtcpInstance->setSpecificRRHandler(fTransport.u.destAddr,
+                                                   fTransport.u.rtcpDestPort,
+                                                   rtcpRRHandler,
+                                                   rtcpRRHandlerClientData);
+            }
+
+            rtcpInstance->sendReport(); // Send initial RTCP report
+        }
+        else
+        {
+            LOG_WARN("Failed to create RTCPInstance for session " << clientSessionId);
+        }
+
+        // Connect the sink to the source
+        if (!mediaSink->startPlaying(*rtpSource, nullptr, this))
+        {
+            LOG_ERROR("mediaSink->startPlaying failed for client session " << clientSessionId);
+            Medium::close(rtcpInstance);
+            rtcpInstance = nullptr;
+        }
+    }
+    else
+    {
+        if (!mediaSink)
+            LOG_ERROR("Cannot start playing - mediaSink is NULL for client session "
+                      << clientSessionId);
+        else if (!rtpSource)
+            LOG_ERROR("Cannot start playing - rtpSource is NULL for client session "
+                      << clientSessionId);
+        else
+            LOG_ERROR("Cannot start playing - unknown reason for client session "
+                      << clientSessionId);
+    }
+}

--- a/src/BackchannelStreamState.hpp
+++ b/src/BackchannelStreamState.hpp
@@ -1,0 +1,78 @@
+#ifndef BACKCHANNEL_STREAM_STATE_HPP
+#define BACKCHANNEL_STREAM_STATE_HPP
+
+// Manages the state of a backchannel audio stream, associating RTP source,
+// sink, groupsocks, and transport details.
+
+#include "BackchannelSink.hpp"
+
+#include <liveMedia.hh>
+
+struct UdpTransportDetails
+{
+    struct sockaddr_storage destAddr;
+    Port rtpDestPort;
+    Port rtcpDestPort;
+};
+
+struct TcpTransportDetails
+{
+    int tcpSocketNum;
+    unsigned char rtpChannelId;
+    unsigned char rtcpChannelId;
+    TLSState *tlsState;
+};
+
+union TransportSpecificDetails {
+    UdpTransportDetails u;
+    TcpTransportDetails t;
+
+    TransportSpecificDetails() {}
+    ~TransportSpecificDetails() {}
+};
+
+class BackchannelStreamState
+{
+    // Restore friendship to allow subsession access to private members
+    friend class BackchannelServerMediaSubsession;
+
+public:
+    // Constructor takes UsageEnvironment and CNAME instead of master reference
+    BackchannelStreamState(UsageEnvironment &env,
+                           char const *cname,
+                           RTPSource *_rtpSource,
+                           BackchannelSink *_mediaSink,
+                           Groupsock *_rtpGS,
+                           Groupsock *_rtcpGS,
+                           unsigned _clientSessionId,
+                           struct sockaddr_storage const &_destAddr,
+                           Port const &_rtpDestPort,
+                           Port const &_rtcpDestPort,
+                           int _tcpSocketNum,
+                           unsigned char _rtpChannelId,
+                           unsigned char _rtcpChannelId,
+                           TLSState *_tlsState);
+
+    ~BackchannelStreamState();
+
+    // Configures transport and starts the sink playing
+    void startPlaying(TaskFunc *rtcpRRHandler,
+                      void *rtcpRRHandlerClientData,
+                      ServerRequestAlternativeByteHandler *serverRequestAlternativeByteHandler,
+                      void *serverRequestAlternativeByteHandlerClientData);
+
+private:
+    UsageEnvironment &fEnv;
+    char const *fCNAME; // CNAME for RTCP reports
+    RTPSource *rtpSource;
+    BackchannelSink *mediaSink;
+    Groupsock *rtpGS;
+    Groupsock *rtcpGS;          // Groupsock for RTCP
+    RTCPInstance *rtcpInstance; // RTCP instance associated with the stream
+    unsigned clientSessionId;   // ID of the client for this stream
+
+    Boolean fIsTCP;                      // Flag indicating TCP or UDP transport
+    TransportSpecificDetails fTransport; // Union holding transport-specific details
+};
+
+#endif // BACKCHANNEL_STREAM_STATE_HPP

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -82,11 +82,18 @@ bool validateUint(const unsigned int &v)
     return true;
 }
 
+bool validateSampleRate(const int &v)
+{
+    std::set<int> allowed_rates = {8000, 16000, 24000, 44100, 48000};
+    return allowed_rates.count(v) == 1;
+}
+
 std::vector<ConfigItem<bool>> CFG::getBoolItems()
 {
     return {
 #if defined(AUDIO_SUPPORT)
         {"audio.input_enabled", audio.input_enabled, true, validateBool},
+        {"audio.output_enabled", audio.output_enabled, false, validateBool},
         {"audio.force_stereo", audio.force_stereo, false, validateBool},
 #if defined(LIB_AUDIO_PROCESSING)
         {"audio.input_high_pass_filter", audio.input_high_pass_filter, false, validateBool},
@@ -179,10 +186,8 @@ std::vector<ConfigItem<int>> CFG::getIntItems()
     return {
 #if defined(AUDIO_SUPPORT)
         {"audio.input_bitrate", audio.input_bitrate, 40, [](const int &v) { return v >= 6 && v <= 256; }},
-        {"audio.input_sample_rate", audio.input_sample_rate, 16000, [](const int &v) {
-            std::set<int> a = {8000, 16000, 24000, 44100, 48000};
-            return a.count(v) == 1;
-        }},
+        {"audio.input_sample_rate", audio.input_sample_rate, 16000, validateSampleRate},
+        {"audio.output_sample_rate", audio.output_sample_rate, 16000, validateSampleRate},
         {"audio.input_vol", audio.input_vol, 80, [](const int &v) { return v >= -30 && v <= 120; }},
         {"audio.input_gain", audio.input_gain, 25, [](const int &v) { return v >= -1 && v <= 31; }},
 #if defined(LIB_AUDIO_PROCESSING)

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -141,7 +141,7 @@ struct _image {
     int wb_bgain;
 
 };
-#if defined(AUDIO_SUPPORT)        
+#if defined(AUDIO_SUPPORT)
 struct _audio {
     bool input_enabled;
     const char *input_format;
@@ -150,13 +150,15 @@ struct _audio {
     int input_gain;
     int input_sample_rate;
 #if defined(LIB_AUDIO_PROCESSING)
-    int input_alc_gain;  
-    int input_noise_suppression;            
+    int input_alc_gain;
+    int input_noise_suppression;
     bool input_high_pass_filter;
     bool input_agc_enabled;
     int input_agc_target_level_dbfs;
     int input_agc_compression_gain_db;
     bool force_stereo;
+    bool output_enabled;
+    int output_sample_rate;
 #endif
 };
 #endif      

--- a/src/IMPBackchannel.cpp
+++ b/src/IMPBackchannel.cpp
@@ -1,0 +1,53 @@
+#include "IMPBackchannel.hpp"
+
+#include "Config.hpp"
+#include "Logger.hpp"
+
+#include <imp/imp_audio.h>
+
+#define MODULE "IMPBackchannel"
+
+IMPBackchannel *IMPBackchannel::createNew()
+{
+    return new IMPBackchannel();
+}
+
+int IMPBackchannel::init()
+{
+    LOG_DEBUG("IMPBackchannel::init()");
+    int ret = 0;
+
+    IMPAudioDecChnAttr adec_attr;
+    adec_attr.mode = ADEC_MODE_PACK;
+
+    // Create G711U channel
+    adec_attr.bufSize = 20; // Default buffer size for G711
+    adec_attr.type = PT_G711U;
+    int adChn = (int) IMPBackchannelFormat::PCMU;
+    ret = IMP_ADEC_CreateChn(adChn, &adec_attr);
+    LOG_DEBUG_OR_ERROR(ret, "IMP_ADEC_CreateChn(PCMU, " << adChn << ")");
+
+    // Create G711A channel
+    adec_attr.bufSize = 20; // Default buffer size for G711
+    adec_attr.type = PT_G711A;
+    adChn = (int) IMPBackchannelFormat::PCMA;
+    ret = IMP_ADEC_CreateChn(adChn, &adec_attr);
+    LOG_DEBUG_OR_ERROR(ret, "IMP_ADEC_CreateChn(PCMA, " << adChn << ")");
+
+    return 0;
+}
+
+void IMPBackchannel::deinit()
+{
+    LOG_DEBUG("IMPBackchannel::deinit()");
+    int ret;
+
+#define DESTROY_ADEC(EnumName, NameString, PayloadType, Frequency, MimeType) \
+    { \
+        int adChn = (int) IMPBackchannelFormat::EnumName; \
+        ret = IMP_ADEC_DestroyChn(adChn); \
+        LOG_DEBUG_OR_ERROR(ret, "IMP_ADEC_DestroyChn(" #EnumName ", " << adChn << ")"); \
+    }
+    X_FOREACH_BACKCHANNEL_FORMAT(DESTROY_ADEC)
+#undef DESTROY_ADEC
+}

--- a/src/IMPBackchannel.hpp
+++ b/src/IMPBackchannel.hpp
@@ -1,0 +1,62 @@
+#ifndef IMP_BACKCHANNEL_HPP
+#define IMP_BACKCHANNEL_HPP
+
+/*
+ *  Backchannel Audio Pipeline: Architecture Overview
+ *
+ *  This module manages backchannel audio, enabling two-way audio
+ *  communication from an RTSP client. It involves setting up audio
+ *  channels with the IMP audio SDK for decoding received audio.
+ *
+ *  Key aspects of the pipeline:
+ *   1. RTSP Setup and SDP: The RTSP server creates a
+ *      BackchannelServerMediaSubsession for each supported audio format.
+ *      The SDP (Session Description Protocol) defines the audio stream
+ *      parameters (e.g., codec, sample rate) for the client.
+ *   2. Audio Reception and Timeout: The BackchannelSink receives
+ *      encoded audio data from the RTSP client and implements a timeout
+ *      mechanism. If no data is received for a certain period, it sends
+ *      a "stop" frame to signal the end of the session.
+ *   3. Frame Queueing: The BackchannelSink encapsulates the received data
+ *      into BackchannelFrame objects and enqueues them in a global queue
+ *      (global_backchannel->inputQueue). These frames can be either
+ *      playback frames (containing audio data) or stop frames (with empty
+ *      payload, signaling the end of a session).
+ *   4. Audio Processing and Session Management: The BackchannelProcessor
+ *      dequeues frames from the queue, decodes the audio data using the
+ *      IMP audio SDK, and resamples it if necessary. It maintains a
+ *      concept of a "current" session, processing only frames from that
+ *      session and discarding frames from other sessions.
+ *   5. Audio Output: The decoded PCM audio is then sent to a pipe, where
+ *      the `/bin/iac` program receives the data and handles the audio
+ *      output.
+ *
+ *  The IMPBackchannel class is responsible for:
+ *   - Registering and managing audio decoders (e.g., AAC) with the IMP
+ *     audio SDK.
+ *   - Creating and destroying the IMP audio channels used for decoding.
+ */
+
+// Define the list of backchannel formats and their properties
+// X(EnumName, NameString, PayloadType, Frequency, MimeType)
+#define X_FOREACH_BACKCHANNEL_FORMAT(X) \
+    /* PCMU must come first as it is a mandatory ONVIF Profile-T format. */ \
+    X(PCMU, "PCMU", 0, 8000, "audio/PCMU") \
+    X(PCMA, "PCMA", 8, 8000, "audio/PCMA") \
+    /* Add new formats here */
+
+#define APPLY_ENUM(EnumName, NameString, PayloadType, Frequency, MimeType) EnumName,
+enum class IMPBackchannelFormat { UNKNOWN = -1, X_FOREACH_BACKCHANNEL_FORMAT(APPLY_ENUM) };
+#undef APPLY_ENUM
+
+class IMPBackchannel
+{
+public:
+    static IMPBackchannel *createNew();
+    IMPBackchannel() { init(); }
+    ~IMPBackchannel() { deinit(); };
+    int init();
+    void deinit();
+};
+
+#endif // IMP_BACKCHANNEL_HPP

--- a/src/RTSP.cpp
+++ b/src/RTSP.cpp
@@ -1,4 +1,6 @@
 #include "RTSP.hpp"
+#include "IMPBackchannel.hpp"
+#include "BackchannelServerMediaSubsession.hpp"
 
 #define MODULE "RTSP"
 
@@ -76,6 +78,20 @@ void RTSP::addSubsession(int chnNr, _stream &stream)
         IMPAudioServerMediaSubsession *audioSub = IMPAudioServerMediaSubsession::createNew(*env, 0);
         sms->addSubsession(audioSub);
         LOG_INFO("Audio stream " << chnNr << " added to session");
+    }
+
+    if (cfg->audio.output_enabled && stream.audio_enabled)
+    {
+        #define ADD_BACKCHANNEL_SUBSESSION(EnumName, NameString, PayloadType, Frequency, MimeType) \
+            { \
+                BackchannelServerMediaSubsession* backchannelSub = \
+                    BackchannelServerMediaSubsession::createNew(*env, IMPBackchannelFormat::EnumName); \
+                sms->addSubsession(backchannelSub); \
+                LOG_INFO("Backchannel stream " << NameString << " added to session"); \
+            }
+
+        X_FOREACH_BACKCHANNEL_FORMAT(ADD_BACKCHANNEL_SUBSESSION)
+        #undef ADD_BACKCHANNEL_SUBSESSION
     }
 #endif
 

--- a/src/WS.cpp
+++ b/src/WS.cpp
@@ -224,7 +224,9 @@ enum
     PNT_AUDIO_INPUT_AGC_COMPRESSION_GAIN_DB,
     PNT_AUDIO_INPUT_BITRATE,
     PNT_AUDIO_INPUT_FORMAT,
-    PNT_AUDIO_INPUT_SAMPLE_RATE
+    PNT_AUDIO_INPUT_SAMPLE_RATE,
+    PNT_AUDIO_OUTPUT_ENABLED,
+    PNT_AUDIO_OUTPUT_SAMPLE_RATE
 };
 
 static const char *const audio_keys[] = {
@@ -239,7 +241,9 @@ static const char *const audio_keys[] = {
     "input_agc_compression_gain_db",
     "input_bitrate",
     "input_format",
-    "input_sample_rate"};
+    "input_sample_rate",
+    "output_enabled",
+    "output_sample_rate"};
 #endif
 
 /* STREAM */
@@ -1131,7 +1135,8 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
         // integer values
         else if (ctx->path_match == PNT_AUDIO_INPUT_NOISE_SUPPRESSION || 
                  ctx->path_match == PNT_AUDIO_INPUT_SAMPLE_RATE ||
-                 ctx->path_match == PNT_AUDIO_INPUT_BITRATE )
+                 ctx->path_match == PNT_AUDIO_INPUT_BITRATE ||
+                 ctx->path_match == PNT_AUDIO_OUTPUT_SAMPLE_RATE )
         {
             if (reason == LEJPCB_VAL_NUM_INT)
             {
@@ -1185,6 +1190,25 @@ signed char WS::audio_callback(struct lejp_ctx *ctx, char reason)
         {
             switch (ctx->path_match)
             {
+            case PNT_AUDIO_OUTPUT_ENABLED:
+                if (reason == LEJPCB_VAL_TRUE)
+                {
+                    if (cfg->set<bool>(u_ctx->path, true))
+                    {
+                        global_restart_audio = true;
+                        global_restart_rtsp = true;
+                    }
+                }
+                else if (reason == LEJPCB_VAL_FALSE)
+                {
+                    if (cfg->set<bool>(u_ctx->path, false))
+                    {
+                        global_restart_audio = true;
+                        global_restart_rtsp = true;
+                    }
+                }
+                add_json_bool(u_ctx->message, cfg->get<bool>(u_ctx->path));
+                break;
             case PNT_AUDIO_INPUT_ENABLED:
                 if (reason == LEJPCB_VAL_TRUE)
                 {

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1,4 +1,5 @@
 #include "worker.hpp"
+#include "BackchannelProcessor.hpp"
 #include "Motion.hpp"
 #include "AudioReframer.hpp"
 #include <cmath>
@@ -852,4 +853,23 @@ void *Worker::watch_config_poll(void *arg)
 
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
+}
+
+void *Worker::backchannel_processor(void *arg)
+{
+    LOG_INFO("Backchannel processor thread starting...");
+
+    StartHelper *sh = static_cast<StartHelper *>(arg);
+    global_backchannel->imp_backchannel = IMPBackchannel::createNew();
+
+    BackchannelProcessor processor;
+    sh->has_started.release();
+    processor.run();
+
+    global_backchannel->imp_backchannel->deinit();
+    delete global_backchannel->imp_backchannel;
+    global_backchannel->imp_backchannel = nullptr;
+
+    LOG_INFO("Backchannel processor thread finished.");
+    return nullptr;
 }

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -35,6 +35,7 @@ public:
 	static void *watch_config_notify(void *arg);
 	static void *watch_config_poll(void *arg);
 	static std::vector<uint8_t> capture_jpeg_image(int encChn);
+	static void *backchannel_processor(void *arg);
 };
 
 #endif


### PR DESCRIPTION
## Summary

This Pull Request introduces the **Backchannel Audio Pipeline**, enabling two-way audio communication from an RTSP client. It sets up and manages audio channels using the IMP audio SDK for decoding received audio streams. The current supported codecs are G711U and G711A. AAC has not been added (yet) but there is experimental Opus support on a [different branch](https://github.com/nschimme/prudynt-t/tree/backchannel_opus).

---

## Architecture Overview

The backchannel audio pipeline consists of the following key components:

1. **RTSP Setup and SDP**  
   The RTSP server creates a `BackchannelServerMediaSubsession` for each supported audio format.  
   The Session Description Protocol (SDP) defines audio stream parameters such as codec and sample rate for the client.

2. **Audio Reception and Timeout**  
   The `BackchannelSink` receives encoded audio data from the RTSP client and implements a timeout mechanism.  
   If no data is received within a specified period, it sends a "stop" frame to signal the end of the session.

3. **Frame Queueing**  
   The `BackchannelSink` encapsulates the received audio into `BackchannelFrame` objects and enqueues them in a global queue (`global_backchannel->inputQueue`).  
   Frames can either contain playback audio data or be stop frames (empty payloads signaling session end).

4. **Audio Processing and Session Management**  
   The `BackchannelProcessor` dequeues frames from the global queue, decodes the audio using the IMP audio SDK, and resamples it if necessary.  
   It maintains a "current" session, ensuring only frames from the active session are processed, while frames from stale sessions are discarded.

5. **Audio Output**  
   The decoded PCM audio is sent to a pipe, where the `/bin/iac` program reads the data and handles audio playback.

## Testing ONVIF Profile-T on Thingino

1. Enable `output_enabled` in `/etc/prudynt.cfg` for the `audio` block.
1. Edit `/etc/onvif.conf` and change `audio_decoder=NONE` to `audio_decoder=G711`
1. Restart the camera. It should just work. I tested on Frigate and Scrypted.
